### PR TITLE
Initial Setup: Add pubspec.yaml with Static Dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.19.4'
+          flutter-version: '3.19.5'
           channel: 'stable'
           cache: true
       

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.19.5'
+          flutter-version: '3.29.3'
           channel: 'stable'
           cache: true
       

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Run Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.19.0'
+          channel: 'stable'
+          cache: true
+      
+      - name: Install dependencies
+        run: flutter pub get
+      
+      - name: Run tests
+        run: flutter test 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.19.0'
+          flutter-version: '3.19.4'
           channel: 'stable'
           cache: true
       

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 repository: https://github.com/your-username/custom_lint_library
 
 environment:
-  sdk: '>=3.5.0 <4.0.0'
+  sdk: '3.3.0'
 
 dependencies:
   custom_lint_builder: 0.7.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 repository: https://github.com/your-username/custom_lint_library
 
 environment:
-  sdk: '3.3.0'
+  sdk: '3.4.0'
 
 dependencies:
   custom_lint_builder: 0.7.5
@@ -13,4 +13,4 @@ dependencies:
   source_span: 1.10.1
 
 dev_dependencies:
-  test: 1.26.2 
+  test: 1.25.7 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 repository: https://github.com/your-username/custom_lint_library
 
 environment:
-  sdk: '3.4.0'
+  sdk: '3.7.2'
 
 dependencies:
   custom_lint_builder: 0.7.5
@@ -13,4 +13,4 @@ dependencies:
   source_span: 1.10.1
 
 dev_dependencies:
-  test: 1.25.7 
+  test: 1.26.2 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,10 +7,10 @@ environment:
   sdk: '>=3.5.0 <4.0.0'
 
 dependencies:
-  custom_lint_builder: ^0.7.4
+  custom_lint_builder: 0.7.5
   analyzer: 7.3.0
-  analyzer_plugin: ^0.13.0
-  source_span: ^1.10.0
+  analyzer_plugin: 0.13.0
+  source_span: 1.10.1
 
 dev_dependencies:
-  test: ^1.25.0 
+  test: 1.26.2 


### PR DESCRIPTION
## Description
This PR sets up the initial project structure with a carefully selected set of static dependencies in `pubspec.yaml`. The dependencies are pinned to specific versions to ensure build stability and prevent unexpected breaking changes.

## Changes
- Added `pubspec.yaml` with the following static dependencies:
  - `custom_lint_builder: 0.7.5`
  - `analyzer: 7.3.0`
  - `analyzer_plugin: 0.13.0`
  - `source_span: 1.10.1`
  - `test: 1.26.2` (dev dependency)

## Why Static Dependencies?
- **Build Stability**: By pinning dependencies to specific versions, we ensure that all developers and CI/CD pipelines use exactly the same package versions
- **Prevent Breaking Changes**: Automatic updates to dependencies can introduce breaking changes that might not be immediately apparent
- **Reproducible Builds**: Static dependencies guarantee that builds are reproducible across different environments and time periods
- **Controlled Updates**: Dependencies can be updated intentionally through a controlled process rather than automatically

## Future Considerations
- Dependencies should only be updated after thorough testing and review
- Consider implementing a dependency update policy