### PR TITLE
Adds a new lint rule that forbids forced unwrapping (`!`) in production code to prevent runtime null errors.

### DIFF
--- a/example/custom_lint.yaml
+++ b/example/custom_lint.yaml
@@ -4,6 +4,7 @@ description: Example custom lint configuration
 rules:
   - prefer_fake_over_mock
   - no_optional_operators_in_tests
+  - forbid_forced_unwrapping
 
 analyzer:
   plugins:

--- a/example/example_forbid_forced_unwrapping_rule.dart
+++ b/example/example_forbid_forced_unwrapping_rule.dart
@@ -1,0 +1,27 @@
+class User {
+  final String? name;
+  final int? age;
+  User({this.name, this.age});
+}
+
+void main() {
+  final user = User(name: null, age: null);
+  
+  // Bad: Using forced unwrapping
+  final name = user.name!;  // LINT
+  final age = user.age!;    // LINT
+  print('User: $name, Age: $age');  // Will crash at runtime
+  
+  // Good: Using null-safe alternatives
+  final safeName = user.name ?? 'Unknown';
+  final safeAge = user.age ?? 0;
+  print('User: $safeName, Age: $safeAge');  // Safe, will print "User: Unknown, Age: 0"
+  
+  // Good: Using explicit null checks
+  if (user.name != null) {
+    final checkedName = user.name;  // Safe after null check
+    print('User name is: $checkedName');
+  } else {
+    print('User name is not set');
+  }
+} 

--- a/lib/ripplearc_flutter_lint.dart
+++ b/lib/ripplearc_flutter_lint.dart
@@ -1,13 +1,15 @@
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'rules/prefer_fake_over_mock_rule.dart';
-import 'src/rules/no_optional_operators_in_tests.dart';
+import 'rules/forbid_forced_unwrapping.dart';
+import 'rules/no_optional_operators_in_tests.dart';
 
 PluginBase createPlugin() => _RipplearcFlutterLint();
 
 class _RipplearcFlutterLint extends PluginBase {
   @override
   List<LintRule> getLintRules(CustomLintConfigs configs) => [
-        const PreferFakeOverMockRule(),
+        const ForbidForcedUnwrapping(),
         const NoOptionalOperatorsInTests(),
+        const PreferFakeOverMockRule(),
       ];
 } 

--- a/lib/rules/forbid_forced_unwrapping.dart
+++ b/lib/rules/forbid_forced_unwrapping.dart
@@ -1,0 +1,74 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart' hide LintCode;
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// A lint rule that forbids using forced unwrapping (`!`) in production code.
+///
+/// This rule flags forced unwrapping operators to ensure null values are handled
+/// explicitly using null-safe alternatives like null coalescing (`??`) or explicit
+/// null checks. This helps prevent runtime crashes and makes the code more robust.
+///
+/// Example of code that triggers this rule:
+/// ```dart
+/// final name = user.name!;  // Will crash if name is null
+/// print('User: $name');
+/// ```
+///
+/// Example of code that doesn't trigger this rule:
+/// ```dart
+/// final name = user.name ?? 'Unknown';  // Safe with default value
+/// print('User: $name');
+///
+/// if (user.name != null) {
+///   final checkedName = user.name;  // Safe after null check
+///   print('User: $checkedName');
+/// }
+/// ```
+class ForbidForcedUnwrapping extends DartLintRule {
+  const ForbidForcedUnwrapping() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'forbid_forced_unwrapping',
+    problemMessage: 'Forced unwrapping (!) is not allowed in production code.',
+    correctionMessage: 'Use null-safe alternatives like null coalescing (??) or explicit null checks.',
+    errorSeverity: ErrorSeverity.ERROR,
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addCompilationUnit((node) {
+      if (_isTestFile(resolver.path)) return;
+      _checkForForcedUnwrapping(node, reporter);
+    });
+  }
+
+  bool _isTestFile(String path) {
+    return path.contains('_test.dart') || path.contains('/test/');
+  }
+
+  void _checkForForcedUnwrapping(CompilationUnit node, ErrorReporter reporter) {
+    final visitor = _ForcedUnwrappingVisitor(reporter);
+    node.accept(visitor);
+  }
+}
+
+class _ForcedUnwrappingVisitor extends RecursiveAstVisitor<void> {
+  _ForcedUnwrappingVisitor(this.reporter);
+
+  final ErrorReporter reporter;
+
+  @override
+  void visitPostfixExpression(PostfixExpression node) {
+    if (node.operator.type == TokenType.BANG) {
+      reporter.atNode(node, ForbidForcedUnwrapping._code);
+    }
+    super.visitPostfixExpression(node);
+  }
+} 

--- a/lib/rules/no_optional_operators_in_tests.dart
+++ b/lib/rules/no_optional_operators_in_tests.dart
@@ -35,7 +35,7 @@ class NoOptionalOperatorsInTests extends DartLintRule {
     name: 'no_optional_operators_in_tests',
     problemMessage: 'Optional operators (?., ??) are not allowed in test blocks. Tests should fail explicitly at the point of failure.',
     correctionMessage: 'Remove the optional operator and add an explicit null check if needed.',
-    errorSeverity: ErrorSeverity.WARNING,
+    errorSeverity: ErrorSeverity.ERROR,
   );
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ripplearc_flutter_lint
 description: A custom lint library providing rules like prefer_fake_over_mock for better testing practices
-version: 1.0.0
-repository: https://github.com/your-username/custom_lint_library
+version: 0.1.0
+repository: https://github.com/ripplearc/ripplearc-flutter-lint
 
 environment:
   sdk: '>=3.7.2 <4.0.0'

--- a/test/rules/forbid_forced_unwrapping_test.dart
+++ b/test/rules/forbid_forced_unwrapping_test.dart
@@ -1,0 +1,113 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/source/line_info.dart';
+import 'package:analyzer/source/source.dart';
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:ripplearc_flutter_lint/rules/forbid_forced_unwrapping.dart';
+import 'package:test/test.dart';
+import '../utils/test_error_reporter.dart';
+
+void main() {
+  group('ForbidForcedUnwrapping', () {
+    late ForbidForcedUnwrapping rule;
+    late TestErrorReporter reporter;
+    late CompilationUnit unit;
+
+    setUp(() {
+      rule = const ForbidForcedUnwrapping();
+      reporter = TestErrorReporter();
+    });
+
+    Future<void> analyzeCode(String sourceCode, {required String path}) async {
+      final parseResult = parseString(content: sourceCode);
+      unit = parseResult.unit;
+      rule.run(
+        TestCustomLintResolver(unit, path),
+        reporter,
+        TestCustomLintContext(unit),
+      );
+    }
+
+    test('should flag forced unwrapping in production code', () async {
+      const source = '''
+      void main() {
+        final String? name = null;
+        final value = name!;  // Should flag this
+        print(value);
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/example.dart');
+      expect(reporter.errors, hasLength(1));
+      expect(reporter.errors.first.errorCode.name, equals('forbid_forced_unwrapping'));
+    });
+
+    test('should not flag forced unwrapping in test files', () async {
+      const source = '''
+      void main() {
+        test('example', () {
+          final String? name = null;
+          final value = name!;  // Should not flag this in test files
+          expect(value, equals('test'));
+        });
+      }
+      ''';
+      await analyzeCode(source, path: 'test/example_test.dart');
+      expect(reporter.errors, isEmpty);
+    });
+  });
+}
+
+class TestCustomLintResolver implements CustomLintResolver {
+  TestCustomLintResolver(this.unit, this.path);
+  final CompilationUnit unit;
+  @override
+  final String path;
+
+  @override
+  Future<ResolvedUnitResult> getResolvedUnitResult() async {
+    throw UnimplementedError();
+  }
+
+  @override
+  LineInfo get lineInfo => throw UnimplementedError();
+
+  @override
+  Source get source => throw UnimplementedError();
+}
+
+class _MockLintRuleNodeRegistry implements LintRuleNodeRegistry {
+  final CompilationUnit unit;
+
+  _MockLintRuleNodeRegistry(this.unit);
+
+  @override
+  void addCompilationUnit(Function(CompilationUnit) callback) {
+    callback(unit);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => throw UnimplementedError();
+}
+
+class TestCustomLintContext implements CustomLintContext {
+  TestCustomLintContext(this.unit);
+  final CompilationUnit unit;
+
+  void addCompilationUnit(Function(CompilationUnit) callback) {
+    callback(unit);
+  }
+
+  @override
+  void addPostRunCallback(Function() callback) {}
+
+  @override
+  Pubspec get pubspec => throw UnimplementedError();
+
+  @override
+  Map<String, dynamic> get sharedState => {};
+
+  @override
+  LintRuleNodeRegistry get registry => _MockLintRuleNodeRegistry(unit);
+} 

--- a/test/rules/no_optional_operators_in_tests_test.dart
+++ b/test/rules/no_optional_operators_in_tests_test.dart
@@ -6,7 +6,7 @@ import 'package:analyzer/dart/analysis/results.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:test/test.dart';
-import 'package:ripplearc_flutter_lint/src/rules/no_optional_operators_in_tests.dart';
+import 'package:ripplearc_flutter_lint/rules/no_optional_operators_in_tests.dart';
 import '../utils/test_error_reporter.dart';
 
 void main() {


### PR DESCRIPTION
## Changes
- Added `ForbidForcedUnwrapping` rule to detect forced unwrapping in production code
- Added example file demonstrating violations and correct usage
- Updated README with rule documentation
- Changed severity to ERROR for both `ForbidForcedUnwrapping` and `NoOptionalOperatorsInTests` rules
- Updated package version to 0.1.0

## Why This Rule?
Forced unwrapping (`!`) can lead to runtime crashes when the value is null. This rule encourages developers to handle null values explicitly using null-safe alternatives like null coalescing (`??`) or explicit null checks, making the code more robust and predictable.
