### PR TITLE
Add document interface in the prod code

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,18 @@ lib/
     prefer_fake_over_mock_rule.dart
     no_optional_operators_in_tests.dart
     forbid_forced_unwrapping.dart
+    document_interface.dart
 test/
   rules/                    # All rule tests go here
     prefer_fake_over_mock_rule_test.dart
     no_optional_operators_in_tests_test.dart
     forbid_forced_unwrapping_test.dart
+    document_interface_test.dart
 example/                    # Example files demonstrating rules
   example_prefer_fake_over_mock_rule.dart
   example_no_optional_operators_in_tests_rule.dart
   example_forbid_forced_unwrapping_rule.dart
+  example_document_interface_rule.dart
 ```
 
 ## Rules
@@ -74,6 +77,50 @@ test('example', () {
   final result = someObject.someProperty;  // Will fail explicitly if null
   expect(result, equals(expected));
 });
+```
+
+### document_interface
+
+Enforces documentation on abstract classes and their public methods. This rule ensures clear API contracts for modular architecture by requiring `///` documentation for both the class and its public methods. Private methods and concrete classes are ignored.
+
+#### Bad ❌
+```dart
+abstract class SyncRepository {
+  Future<void> syncData();  // Missing method documentation
+  Future<void> clearData(); // Missing method documentation
+}
+
+/// Repository interface for data synchronization operations.
+abstract class UserRepository {
+  Future<String> getUser(String id);  // Missing method documentation
+}
+```
+
+#### Good ✅
+```dart
+/// Repository interface for data synchronization operations.
+abstract class DataRepository {
+  /// Synchronizes local data with remote Supabase instance.
+  /// Returns true if synchronization was successful.
+  Future<bool> syncData();
+
+  /// Clears all local data from the repository.
+  /// This operation cannot be undone.
+  Future<void> clearData();
+
+  /// Retrieves data by its unique identifier.
+  /// Returns null if no data is found for the given id.
+  Future<String?> getData(String id);
+}
+
+// Private methods are ignored (no documentation required)
+/// Repository interface for data synchronization operations.
+abstract class SecureRepository {
+  /// Synchronizes local data with remote Supabase instance.
+  Future<bool> syncData();
+
+  Future<void> _validateData(); // Private method - no documentation needed
+}
 ```
 
 ## Registering a Custom Lint Rule
@@ -194,6 +241,7 @@ This configuration file includes all our custom lint rules:
 - `prefer_fake_over_mock` - Prefer using Fake over Mock for test doubles
 - `forbid_forced_unwrapping` - Forbid forced unwrapping in production code
 - `no_optional_operators_in_tests` - Forbid optional operators in test files
+- `document_interface` - Enforce documentation on abstract classes and their public methods
 
 #### Rule Configuration
 - Each rule is listed under the `rules` section

--- a/example/custom_lint.yaml
+++ b/example/custom_lint.yaml
@@ -5,6 +5,7 @@ rules:
   - prefer_fake_over_mock
   - no_optional_operators_in_tests
   - forbid_forced_unwrapping
+  - document_interface
 
 analyzer:
   plugins:

--- a/example/example_document_interface_rule.dart
+++ b/example/example_document_interface_rule.dart
@@ -1,0 +1,50 @@
+// Bad: Abstract class without documentation
+abstract class SyncRepository {
+  Future<void> syncData(); // LINT: Missing method documentation
+  Future<void> clearData(); // LINT: Missing method documentation
+}
+
+// Bad: Abstract class with only class documentation
+/// Repository interface for data synchronization operations.
+abstract class UserRepository {
+  Future<String> getUser(String id); // LINT: Missing method documentation
+  Future<void> updateUser(
+      String id, String name); // LINT: Missing method documentation
+}
+
+// Good: Abstract class with proper documentation
+/// Repository interface for data synchronization operations.
+abstract class DataRepository {
+  /// Synchronizes local data with remote Supabase instance.
+  /// Returns true if synchronization was successful.
+  Future<bool> syncData();
+
+  /// Clears all local data from the repository.
+  /// This operation cannot be undone.
+  Future<void> clearData();
+
+  /// Retrieves data by its unique identifier.
+  /// Returns null if no data is found for the given id.
+  Future<String?> getData(String id);
+}
+
+// Good: Private methods are ignored (no documentation required)
+/// Repository interface for data synchronization operations.
+abstract class SecureRepository {
+  /// Synchronizes local data with remote Supabase instance.
+  Future<bool> syncData();
+
+  Future<void> _validateData(); // Private method - no documentation needed
+  Future<void> _encryptData(); // Private method - no documentation needed
+}
+
+// Good: Concrete classes are ignored (no documentation required)
+class LocalRepository {
+  Future<void> syncData() async {
+    // Implementation
+  }
+
+  Future<void> clearData() async {
+    // Implementation
+  }
+}

--- a/lib/ripplearc_flutter_lint.dart
+++ b/lib/ripplearc_flutter_lint.dart
@@ -2,14 +2,16 @@ import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'rules/prefer_fake_over_mock_rule.dart';
 import 'rules/forbid_forced_unwrapping.dart';
 import 'rules/no_optional_operators_in_tests.dart';
+import 'rules/document_interface.dart';
 
 PluginBase createPlugin() => _RipplearcFlutterLint();
 
 class _RipplearcFlutterLint extends PluginBase {
   @override
   List<LintRule> getLintRules(CustomLintConfigs configs) => [
-        const ForbidForcedUnwrapping(),
-        const NoOptionalOperatorsInTests(),
-        const PreferFakeOverMockRule(),
-      ];
-} 
+    const ForbidForcedUnwrapping(),
+    const NoOptionalOperatorsInTests(),
+    const PreferFakeOverMockRule(),
+    const DocumentInterface(),
+  ];
+}

--- a/lib/rules/document_interface.dart
+++ b/lib/rules/document_interface.dart
@@ -51,10 +51,7 @@ class DocumentInterface extends DartLintRule {
   }
 
   bool _isTestFile(String path) {
-    return path.contains('_test.dart') ||
-        path.contains('/test/') ||
-        path.contains('/example/') ||
-        path.contains('example_');
+    return path.contains('_test.dart') || path.contains('/test/');
   }
 
   void _checkForDocumentation(CompilationUnit node, ErrorReporter reporter) {

--- a/lib/rules/document_interface.dart
+++ b/lib/rules/document_interface.dart
@@ -1,0 +1,117 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/error/error.dart' hide LintCode;
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// A lint rule that ensures abstract classes and their public methods have documentation.
+///
+/// This rule flags abstract classes that are exported/public but lack proper documentation.
+/// It ensures clear API contracts for modular architecture by requiring /// documentation
+/// for both the class and its public methods.
+///
+/// Example of code that triggers this rule:
+/// ```dart
+/// abstract class SyncRepository {  // Missing class documentation
+///   Future<void> syncData();      // Missing method documentation
+/// }
+/// ```
+///
+/// Example of code that doesn't trigger this rule:
+/// ```dart
+/// /// Repository interface for data synchronization operations.
+/// abstract class SyncRepository {
+///   /// Synchronizes local data with remote Supabase instance.
+///   Future<void> syncData();
+/// }
+/// ```
+class DocumentInterface extends DartLintRule {
+  const DocumentInterface() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'document_interface',
+    problemMessage:
+        'Abstract classes and their public methods must have documentation.',
+    correctionMessage:
+        'Add /// documentation for the class and its public methods.',
+    errorSeverity: ErrorSeverity.ERROR,
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addCompilationUnit((node) {
+      if (_isTestFile(resolver.path)) return;
+      _checkForDocumentation(node, reporter);
+    });
+  }
+
+  bool _isTestFile(String path) {
+    return path.contains('_test.dart') ||
+        path.contains('/test/') ||
+        path.contains('/example/') ||
+        path.contains('example_');
+  }
+
+  void _checkForDocumentation(CompilationUnit node, ErrorReporter reporter) {
+    final visitor = _DocumentationVisitor(reporter);
+    node.accept(visitor);
+  }
+}
+
+class _DocumentationVisitor extends RecursiveAstVisitor<void> {
+  _DocumentationVisitor(this.reporter);
+
+  final ErrorReporter reporter;
+
+  @override
+  void visitClassDeclaration(ClassDeclaration node) {
+    // Only check abstract classes
+    if (node.abstractKeyword == null) return;
+
+    // Check if class has documentation
+    final hasClassDocumentation = _hasDocumentation(node.documentationComment);
+
+    // Check public methods for documentation
+    final undocumentedMethods = <MethodDeclaration>[];
+
+    for (final member in node.members) {
+      if (member is MethodDeclaration) {
+        // Only check public methods (not starting with _)
+        if (!member.name.lexeme.startsWith('_')) {
+          if (!_hasDocumentation(member.documentationComment)) {
+            undocumentedMethods.add(member);
+          }
+        }
+      }
+    }
+
+    // Report error if class or any public method lacks documentation
+    if (!hasClassDocumentation || undocumentedMethods.isNotEmpty) {
+      reporter.atNode(node, DocumentInterface._code);
+    }
+
+    super.visitClassDeclaration(node);
+  }
+
+  bool _hasDocumentation(Comment? comment) {
+    if (comment == null) return false;
+
+    // Check for /// documentation (not /** */ or //)
+    for (final token in comment.tokens) {
+      if (token.lexeme.startsWith('///')) {
+        // Check if there's actual content (not just ///)
+        final content = token.lexeme.substring(3).trim();
+        if (content.isNotEmpty) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+}

--- a/test/rules/document_interface_test.dart
+++ b/test/rules/document_interface_test.dart
@@ -114,14 +114,18 @@ void main() {
       expect(reporter.errors, isEmpty);
     });
 
-    test('should not flag abstract classes in example files', () async {
+    test('should flag abstract classes in example files', () async {
       const source = '''
       abstract class ExampleRepository {
         Future<void> syncData();
       }
       ''';
       await analyzeCode(source, path: 'example/example_repository.dart');
-      expect(reporter.errors, isEmpty);
+      expect(reporter.errors, hasLength(1));
+      expect(
+        reporter.errors.first.errorCode.name,
+        equals('document_interface'),
+      );
     });
 
     test('should not flag empty documentation comments', () async {

--- a/test/rules/document_interface_test.dart
+++ b/test/rules/document_interface_test.dart
@@ -1,0 +1,196 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/source/line_info.dart';
+import 'package:analyzer/source/source.dart';
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:ripplearc_flutter_lint/rules/document_interface.dart';
+import 'package:test/test.dart';
+import '../utils/test_error_reporter.dart';
+
+void main() {
+  group('DocumentInterface', () {
+    late DocumentInterface rule;
+    late TestErrorReporter reporter;
+    late CompilationUnit unit;
+
+    setUp(() {
+      rule = const DocumentInterface();
+      reporter = TestErrorReporter();
+    });
+
+    Future<void> analyzeCode(String sourceCode, {required String path}) async {
+      final parseResult = parseString(content: sourceCode);
+      unit = parseResult.unit;
+      rule.run(
+        TestCustomLintResolver(unit, path),
+        reporter,
+        TestCustomLintContext(unit),
+      );
+    }
+
+    test('should flag abstract class without documentation', () async {
+      const source = '''
+      abstract class SyncRepository {
+        Future<void> syncData();
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/repository.dart');
+      expect(reporter.errors, hasLength(1));
+      expect(
+        reporter.errors.first.errorCode.name,
+        equals('document_interface'),
+      );
+    });
+
+    test(
+      'should flag abstract class with undocumented public methods',
+      () async {
+        const source = '''
+      /// Repository interface for data synchronization operations.
+      abstract class SyncRepository {
+        Future<void> syncData();  // Missing documentation
+        Future<void> clearData(); // Missing documentation
+      }
+      ''';
+        await analyzeCode(source, path: 'lib/repository.dart');
+        expect(reporter.errors, hasLength(1));
+        expect(
+          reporter.errors.first.errorCode.name,
+          equals('document_interface'),
+        );
+      },
+    );
+
+    test('should not flag abstract class with proper documentation', () async {
+      const source = '''
+      /// Repository interface for data synchronization operations.
+      abstract class SyncRepository {
+        /// Synchronizes local data with remote Supabase instance.
+        Future<void> syncData();
+        
+        /// Clears all local data.
+        Future<void> clearData();
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/repository.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag private methods', () async {
+      const source = '''
+      /// Repository interface for data synchronization operations.
+      abstract class SyncRepository {
+        /// Synchronizes local data with remote Supabase instance.
+        Future<void> syncData();
+        
+        Future<void> _privateMethod();  // Should not flag private methods
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/repository.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag concrete classes', () async {
+      const source = '''
+      class SyncRepository {
+        Future<void> syncData() async {
+          // Implementation
+        }
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/repository.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag abstract classes in test files', () async {
+      const source = '''
+      abstract class TestRepository {
+        Future<void> syncData();
+      }
+      ''';
+      await analyzeCode(source, path: 'test/repository_test.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag abstract classes in example files', () async {
+      const source = '''
+      abstract class ExampleRepository {
+        Future<void> syncData();
+      }
+      ''';
+      await analyzeCode(source, path: 'example/example_repository.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag empty documentation comments', () async {
+      const source = '''
+      /// 
+      abstract class SyncRepository {
+        /// 
+        Future<void> syncData();
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/repository.dart');
+      expect(reporter.errors, hasLength(1));
+      expect(
+        reporter.errors.first.errorCode.name,
+        equals('document_interface'),
+      );
+    });
+  });
+}
+
+class TestCustomLintResolver implements CustomLintResolver {
+  TestCustomLintResolver(this.unit, this.path);
+  final CompilationUnit unit;
+  @override
+  final String path;
+
+  @override
+  Future<ResolvedUnitResult> getResolvedUnitResult() async {
+    throw UnimplementedError();
+  }
+
+  @override
+  LineInfo get lineInfo => throw UnimplementedError();
+
+  @override
+  Source get source => throw UnimplementedError();
+}
+
+class _MockLintRuleNodeRegistry implements LintRuleNodeRegistry {
+  final CompilationUnit unit;
+
+  _MockLintRuleNodeRegistry(this.unit);
+
+  @override
+  void addCompilationUnit(Function(CompilationUnit) callback) {
+    callback(unit);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => throw UnimplementedError();
+}
+
+class TestCustomLintContext implements CustomLintContext {
+  TestCustomLintContext(this.unit);
+  final CompilationUnit unit;
+
+  void addCompilationUnit(Function(CompilationUnit) callback) {
+    callback(unit);
+  }
+
+  @override
+  void addPostRunCallback(Function() callback) {}
+
+  @override
+  Pubspec get pubspec => throw UnimplementedError();
+
+  @override
+  Map<String, dynamic> get sharedState => {};
+
+  @override
+  LintRuleNodeRegistry get registry => _MockLintRuleNodeRegistry(unit);
+}


### PR DESCRIPTION
Why This Rule?
Abstract classes serve as interfaces for modular architecture, and their public methods define the API contract. Without proper documentation, developers using these interfaces lack clear understanding of the expected behavior, parameters, and return values. This rule enforces /// documentation for both abstract classes and their public methods, ensuring clear API contracts and better code maintainability.

Changes
Added DocumentInterface rule to detect undocumented abstract classes and public methods Added comprehensive test suite covering various scenarios (documented/undocumented, private methods, test files) Added example file demonstrating violations and correct usage patterns Rule excludes test and example files following existing patterns Set severity to ERROR to enforce strict documentation requirements Only applies to abstract classes with public methods (ignores private methods starting with )

Technical Details
Uses RecursiveAstVisitor to traverse AST and identify abstract classes Checks for /// documentation comments with actual content Reports one error per class that has undocumented members Follows existing rule architecture and testing patterns