### PR TITLE
Add document fake parameters in the prod code

### DIFF
--- a/example/custom_lint.yaml
+++ b/example/custom_lint.yaml
@@ -5,6 +5,7 @@ rules:
   - prefer_fake_over_mock
   - no_optional_operators_in_tests
   - forbid_forced_unwrapping
+  - document_fake_parameters
 
 analyzer:
   plugins:

--- a/example/example_document_fake_parameters_rule.dart
+++ b/example/example_document_fake_parameters_rule.dart
@@ -1,0 +1,139 @@
+// Note: This example assumes you have a Fake class available
+// In a real project, you would import the appropriate fake library
+// For example: import 'package:mockito/mockito.dart';
+
+class User {
+  final String id;
+  final String name;
+  final String email;
+
+  User({required this.id, required this.name, required this.email});
+}
+
+// Mock Fake class for demonstration purposes
+class Fake {
+  // This is just for the example - in real code you'd use a proper fake library
+}
+
+abstract class AuthService {
+  Future<void> authenticate();
+  Future<void> logout();
+  Future<bool> isAuthenticated();
+}
+
+abstract class UserRepository {
+  Future<User?> getUser(String id);
+  Future<void> saveUser(User user);
+}
+
+// Bad: Fake class without documentation
+class FakeAuthService extends Fake implements AuthService {
+  void setAuthDelay(Duration delay) {} // LINT: Missing documentation
+  void triggerAuthFailure() {} // LINT: Missing documentation
+
+  @override
+  Future<void> authenticate() async {}
+
+  @override
+  Future<void> logout() async {}
+
+  @override
+  Future<bool> isAuthenticated() async => true;
+}
+
+// Bad: Fake class with only class documentation
+/// Fake implementation of UserRepository for testing.
+class FakeUserRepository extends Fake implements UserRepository {
+  void setUserData(User user) {} // LINT: Missing documentation
+  void triggerNetworkError() {} // LINT: Missing documentation
+
+  @override
+  Future<User?> getUser(String id) async => null;
+
+  @override
+  Future<void> saveUser(User user) async {}
+}
+
+// Good: Fake class with proper documentation
+/// Fake implementation of AuthService for testing authentication scenarios.
+class FakeAuthServiceWithDocs extends Fake implements AuthService {
+  /// Sets authentication delay for testing timing scenarios.
+  /// Useful for testing timeout handling and loading states.
+  void setAuthDelay(Duration delay) {}
+
+  /// Simulates authentication failure for error handling tests.
+  /// Triggers the same error conditions as the real service.
+  void triggerAuthFailure() {}
+
+  /// Simulates network connectivity issues.
+  /// Useful for testing offline scenarios.
+  void simulateNetworkError() {}
+
+  @override
+  Future<void> authenticate() async {} // Override - no documentation needed
+
+  @override
+  Future<void> logout() async {} // Override - no documentation needed
+
+  @override
+  Future<bool> isAuthenticated() async =>
+      true; // Override - no documentation needed
+}
+
+// Good: Private methods are ignored (no documentation required)
+/// Fake implementation of UserRepository for testing.
+class FakeUserRepositoryWithPrivate extends Fake implements UserRepository {
+  /// Sets user data for testing scenarios.
+  void setUserData(User user) {}
+
+  void _validateUser(User user) {} // Private method - no documentation needed
+  void _logUserAction(
+      String action) {} // Private method - no documentation needed
+
+  @override
+  Future<User?> getUser(String id) async => null;
+
+  @override
+  Future<void> saveUser(User user) async {}
+}
+
+// Good: Getters and setters are ignored (no documentation required)
+/// Fake implementation of AuthService for testing.
+class FakeAuthServiceWithGetters extends Fake implements AuthService {
+  /// Sets authentication delay for testing timing scenarios.
+  void setAuthDelay(Duration delay) {}
+
+  bool get authStatus => true; // Getter - no documentation needed
+  set authStatus(bool value) {} // Setter - no documentation needed
+
+  @override
+  Future<void> authenticate() async {}
+
+  @override
+  Future<void> logout() async {}
+
+  @override
+  Future<bool> isAuthenticated() async => true;
+}
+
+// Good: Classes that extend Fake but don't implement interfaces are ignored
+class FakeHelper extends Fake {
+  void setAuthDelay(
+      Duration delay) {} // No interface - no documentation required
+  void triggerAuthFailure() {} // No interface - no documentation required
+}
+
+// Good: Classes that implement interfaces but don't extend Fake are ignored
+class MockAuthService implements AuthService {
+  void setAuthDelay(Duration delay) {} // Not Fake - no documentation required
+  void triggerAuthFailure() {} // Not Fake - no documentation required
+
+  @override
+  Future<void> authenticate() async {}
+
+  @override
+  Future<void> logout() async {}
+
+  @override
+  Future<bool> isAuthenticated() async => true;
+}

--- a/lib/rules/document_fake_parameters.dart
+++ b/lib/rules/document_fake_parameters.dart
@@ -1,0 +1,161 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/error/error.dart' hide LintCode;
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// A lint rule that ensures Fake classes and their non-private members have documentation.
+///
+/// This rule flags Fake classes that implement interfaces but lack proper documentation
+/// for their test helper methods and variables. It improves test maintainability and
+/// ensures test helpers are documented for team collaboration.
+///
+/// Example of code that triggers this rule:
+/// ```dart
+/// class FakeAuthService extends Fake implements AuthService {
+///   void setAuthDelay(Duration delay) { ... }  // Missing documentation
+///   void triggerAuthFailure() { ... }          // Missing documentation
+/// }
+/// ```
+///
+/// Example of code that doesn't trigger this rule:
+/// ```dart
+/// /// Fake implementation of AuthService for testing.
+/// class FakeAuthService extends Fake implements AuthService {
+///   /// Sets authentication delay for testing timing scenarios.
+///   void setAuthDelay(Duration delay) { ... }
+///
+///   /// Simulates authentication failure for error handling tests.
+///   void triggerAuthFailure() { ... }
+///
+///   @override
+///   Future<void> authenticate() async { ... }  // Override - no documentation needed
+/// }
+/// ```
+class DocumentFakeParameters extends DartLintRule {
+  const DocumentFakeParameters() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'document_fake_parameters',
+    problemMessage:
+        'Fake classes and their non-private members must have documentation.',
+    correctionMessage:
+        'Add /// documentation for the class and its non-private members.',
+    errorSeverity: ErrorSeverity.ERROR,
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addCompilationUnit((node) {
+      if (_isTestFile(resolver.path)) return;
+      _checkForDocumentation(node, reporter);
+    });
+  }
+
+  bool _isTestFile(String path) {
+    return path.contains('_test.dart') ||
+        path.contains('/test/') ||
+        path.contains('/example/') ||
+        path.contains('example_');
+  }
+
+  void _checkForDocumentation(CompilationUnit node, ErrorReporter reporter) {
+    final visitor = _FakeDocumentationVisitor(reporter);
+    node.accept(visitor);
+  }
+}
+
+class _FakeDocumentationVisitor extends RecursiveAstVisitor<void> {
+  _FakeDocumentationVisitor(this.reporter);
+
+  final ErrorReporter reporter;
+
+  @override
+  void visitClassDeclaration(ClassDeclaration node) {
+    // Only check classes that extend Fake and implement interfaces
+    if (!_extendsFake(node) || !_implementsInterface(node)) return;
+
+    // Check if class has documentation
+    final hasClassDocumentation = _hasDocumentation(node.documentationComment);
+
+    // Check non-private members for documentation
+    final undocumentedMembers = <AstNode>[];
+
+    for (final member in node.members) {
+      if (_shouldCheckMember(member)) {
+        if (!_hasDocumentation(member.documentationComment)) {
+          undocumentedMembers.add(member);
+        }
+      }
+    }
+
+    // Report error if class or any non-private member lacks documentation
+    if (!hasClassDocumentation || undocumentedMembers.isNotEmpty) {
+      reporter.atNode(node, DocumentFakeParameters._code);
+    }
+
+    super.visitClassDeclaration(node);
+  }
+
+  bool _extendsFake(ClassDeclaration node) {
+    final extendsClause = node.extendsClause;
+    if (extendsClause == null) return false;
+
+    final superclass = extendsClause.superclass;
+    return superclass.name2.lexeme == 'Fake';
+  }
+
+  bool _implementsInterface(ClassDeclaration node) {
+    final implementsClause = node.implementsClause;
+    return implementsClause != null && implementsClause.interfaces.isNotEmpty;
+  }
+
+  bool _shouldCheckMember(ClassMember member) {
+    // Skip private members
+    if (member is MethodDeclaration && member.name.lexeme.startsWith('_')) {
+      return false;
+    }
+    if (member is FieldDeclaration) {
+      for (final field in member.fields.variables) {
+        if (field.name.lexeme.startsWith('_')) {
+          return false;
+        }
+      }
+    }
+
+    // Skip methods with @override annotation (interface method overrides)
+    if (member is MethodDeclaration &&
+        member.metadata.any((m) => m.name.name == 'override')) {
+      return false;
+    }
+
+    // Skip getters and setters
+    if (member is MethodDeclaration && (member.isGetter || member.isSetter)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  bool _hasDocumentation(Comment? comment) {
+    if (comment == null) return false;
+
+    // Check for /// documentation (not /** */ or //)
+    for (final token in comment.tokens) {
+      if (token.lexeme.startsWith('///')) {
+        // Check if there's actual content (not just ///)
+        final content = token.lexeme.substring(3).trim();
+        if (content.isNotEmpty) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+}

--- a/test/rules/document_fake_parameters_test.dart
+++ b/test/rules/document_fake_parameters_test.dart
@@ -1,0 +1,290 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/source/line_info.dart';
+import 'package:analyzer/source/source.dart';
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:ripplearc_flutter_lint/rules/document_fake_parameters.dart';
+import 'package:test/test.dart';
+import '../utils/test_error_reporter.dart';
+
+void main() {
+  group('DocumentFakeParameters', () {
+    late DocumentFakeParameters rule;
+    late TestErrorReporter reporter;
+    late CompilationUnit unit;
+
+    setUp(() {
+      rule = const DocumentFakeParameters();
+      reporter = TestErrorReporter();
+    });
+
+    Future<void> analyzeCode(String sourceCode, {required String path}) async {
+      final parseResult = parseString(content: sourceCode);
+      unit = parseResult.unit;
+      rule.run(
+        TestCustomLintResolver(unit, path),
+        reporter,
+        TestCustomLintContext(unit),
+      );
+    }
+
+    test('should flag Fake class without documentation', () async {
+      const source = '''
+      abstract class AuthService {
+        Future<void> authenticate();
+      }
+      
+      class FakeAuthService extends Fake implements AuthService {
+        void setAuthDelay(Duration delay) { }
+        void triggerAuthFailure() { }
+        
+        @override
+        Future<void> authenticate() async { }
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/auth_service.dart');
+      expect(reporter.errors, hasLength(1));
+      expect(
+        reporter.errors.first.errorCode.name,
+        equals('document_fake_parameters'),
+      );
+    });
+
+    test('should flag Fake class with undocumented methods', () async {
+      const source = '''
+      abstract class AuthService {
+        Future<void> authenticate();
+      }
+      
+      /// Fake implementation of AuthService for testing.
+      class FakeAuthService extends Fake implements AuthService {
+        void setAuthDelay(Duration delay) { }  // Missing documentation
+        void triggerAuthFailure() { }          // Missing documentation
+        
+        @override
+        Future<void> authenticate() async { }
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/auth_service.dart');
+      expect(reporter.errors, hasLength(1));
+      expect(
+        reporter.errors.first.errorCode.name,
+        equals('document_fake_parameters'),
+      );
+    });
+
+    test('should not flag Fake class with proper documentation', () async {
+      const source = '''
+      abstract class AuthService {
+        Future<void> authenticate();
+      }
+      
+      /// Fake implementation of AuthService for testing.
+      class FakeAuthService extends Fake implements AuthService {
+        /// Sets authentication delay for testing timing scenarios.
+        void setAuthDelay(Duration delay) { }
+        
+        /// Simulates authentication failure for error handling tests.
+        void triggerAuthFailure() { }
+        
+        @override
+        Future<void> authenticate() async { }
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/auth_service.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag private methods', () async {
+      const source = '''
+      abstract class AuthService {
+        Future<void> authenticate();
+      }
+      
+      /// Fake implementation of AuthService for testing.
+      class FakeAuthService extends Fake implements AuthService {
+        /// Sets authentication delay for testing timing scenarios.
+        void setAuthDelay(Duration delay) { }
+        
+        void _privateHelper() { }  // Should not flag private methods
+        
+        @override
+        Future<void> authenticate() async { }
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/auth_service.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test(
+      'should not flag classes that extend Fake but do not implement interfaces',
+      () async {
+        const source = '''
+      class FakeAuthService extends Fake {
+        void setAuthDelay(Duration delay) { }
+        void triggerAuthFailure() { }
+      }
+      ''';
+        await analyzeCode(source, path: 'lib/auth_service.dart');
+        expect(reporter.errors, isEmpty);
+      },
+    );
+
+    test(
+      'should not flag classes that implement interfaces but do not extend Fake',
+      () async {
+        const source = '''
+      abstract class AuthService {
+        Future<void> authenticate();
+      }
+      
+      class MockAuthService implements AuthService {
+        void setAuthDelay(Duration delay) { }
+        void triggerAuthFailure() { }
+        
+        @override
+        Future<void> authenticate() async { }
+      }
+      ''';
+        await analyzeCode(source, path: 'lib/auth_service.dart');
+        expect(reporter.errors, isEmpty);
+      },
+    );
+
+    test('should not flag Fake classes in test files', () async {
+      const source = '''
+      abstract class AuthService {
+        Future<void> authenticate();
+      }
+      
+      class FakeAuthService extends Fake implements AuthService {
+        void setAuthDelay(Duration delay) { }
+        void triggerAuthFailure() { }
+        
+        @override
+        Future<void> authenticate() async { }
+      }
+      ''';
+      await analyzeCode(source, path: 'test/auth_service_test.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag Fake classes in example files', () async {
+      const source = '''
+      abstract class AuthService {
+        Future<void> authenticate();
+      }
+      
+      class FakeAuthService extends Fake implements AuthService {
+        void setAuthDelay(Duration delay) { }
+        void triggerAuthFailure() { }
+        
+        @override
+        Future<void> authenticate() async { }
+      }
+      ''';
+      await analyzeCode(source, path: 'example/example_auth_service.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag getters and setters', () async {
+      const source = '''
+      abstract class AuthService {
+        Future<void> authenticate();
+      }
+      
+      /// Fake implementation of AuthService for testing.
+      class FakeAuthService extends Fake implements AuthService {
+        /// Sets authentication delay for testing timing scenarios.
+        void setAuthDelay(Duration delay) { }
+        
+        bool get isAuthenticated => true;  // Should not flag getters
+        set isAuthenticated(bool value) { }  // Should not flag setters
+        
+        @override
+        Future<void> authenticate() async { }
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/auth_service.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag methods with @override annotation', () async {
+      const source = '''
+      abstract class AuthService {
+        Future<void> authenticate();
+        Future<void> logout();
+      }
+      
+      /// Fake implementation of AuthService for testing.
+      class FakeAuthService extends Fake implements AuthService {
+        /// Sets authentication delay for testing timing scenarios.
+        void setAuthDelay(Duration delay) { }
+        
+        @override
+        Future<void> authenticate() async { }  // Should not flag overrides
+        
+        @override
+        Future<void> logout() async { }  // Should not flag overrides
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/auth_service.dart');
+      expect(reporter.errors, isEmpty);
+    });
+  });
+}
+
+class TestCustomLintResolver implements CustomLintResolver {
+  TestCustomLintResolver(this.unit, this.path);
+  final CompilationUnit unit;
+  @override
+  final String path;
+
+  @override
+  Future<ResolvedUnitResult> getResolvedUnitResult() async {
+    throw UnimplementedError();
+  }
+
+  @override
+  LineInfo get lineInfo => throw UnimplementedError();
+
+  @override
+  Source get source => throw UnimplementedError();
+}
+
+class _MockLintRuleNodeRegistry implements LintRuleNodeRegistry {
+  final CompilationUnit unit;
+
+  _MockLintRuleNodeRegistry(this.unit);
+
+  @override
+  void addCompilationUnit(Function(CompilationUnit) callback) {
+    callback(unit);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => throw UnimplementedError();
+}
+
+class TestCustomLintContext implements CustomLintContext {
+  TestCustomLintContext(this.unit);
+  final CompilationUnit unit;
+
+  void addCompilationUnit(Function(CompilationUnit) callback) {
+    callback(unit);
+  }
+
+  @override
+  void addPostRunCallback(Function() callback) {}
+
+  @override
+  Pubspec get pubspec => throw UnimplementedError();
+
+  @override
+  Map<String, dynamic> get sharedState => {};
+
+  @override
+  LintRuleNodeRegistry get registry => _MockLintRuleNodeRegistry(unit);
+}


### PR DESCRIPTION
Adds a new lint rule that ensures Fake classes and their non-private members have proper documentation to improve test maintainability and team collaboration.

Why This Rule?
Fake classes serve as test doubles that implement interfaces and provide test helper methods. Without proper documentation, team members may not understand the purpose and behavior of these test helpers, leading to confusion and maintenance issues. This rule enforces /// documentation for both Fake classes and their non-private methods, ensuring clear understanding of test scenarios and improving collaboration.

Changes
Added DocumentFakeParameters rule to detect undocumented Fake classes and their non-private members Added comprehensive test suite covering various scenarios (documented/undocumented, private methods, overrides, getters/setters) Added example file demonstrating violations and correct usage patterns Rule only applies to classes that extend Fake AND implement interfaces Excludes methods with @override annotations (interface method overrides) Excludes private methods, getters, and setters
Excludes test and example files following existing patterns Set severity to ERROR to enforce strict documentation requirements

Technical Details
Uses RecursiveAstVisitor to traverse AST and identify Fake classes Checks for both extends Fake and implements interface conditions Validates /// documentation comments with actual content Reports one error per class that has undocumented members Follows existing rule architecture and testing patterns Ignores interface method overrides to focus on test helper methods

Benefits
Improves test maintainability by documenting test helper methods Ensures clear API contracts for test doubles
Facilitates team collaboration through better documentation Reduces confusion about test helper method purposes Maintains consistency with existing documentation standards