### PR TITLE
Add no internal method docs in the prod code

### DIFF
--- a/example/custom_lint.yaml
+++ b/example/custom_lint.yaml
@@ -5,6 +5,7 @@ rules:
   - prefer_fake_over_mock
   - no_optional_operators_in_tests
   - forbid_forced_unwrapping
+  - no_internal_method_docs
 
 analyzer:
   plugins:

--- a/example/example_no_internal_method_docs_rule.dart
+++ b/example/example_no_internal_method_docs_rule.dart
@@ -1,0 +1,117 @@
+class User {
+  final String id;
+  final String name;
+
+  User({required this.id, required this.name});
+}
+
+// Bad: Private methods with documentation
+class AuthService {
+  /// Handles internal auth state
+  void _handleAuthState() {} // LINT: Private method should not be documented
+
+  // Validates user input
+  void _validateInput(
+      String input) {} // LINT: Private method should not be documented
+
+  /// Processes user data internally
+  void _processUserData() {} // LINT: Private method should not be documented
+
+  /// Authenticates the user with provided credentials
+  void authenticate() {} // Good: Public method should be documented
+}
+
+// Bad: Multiple private methods with different comment types
+class UserService {
+  /// Internal user validation
+  void _validateUser(
+      User user) {} // LINT: Private method should not be documented
+
+  // Internal data processing
+  void _processUserData() {} // LINT: Private method should not be documented
+
+  /// Retrieves user from database
+  User getUser(String id) {
+    return User(id: id, name: 'Test User');
+  } // Good: Public method should be documented
+}
+
+// Good: Private methods without documentation
+class DataService {
+  void _handleDataProcessing() {} // Good: No documentation needed
+  void _validateData() {} // Good: No documentation needed
+  void _cleanupResources() {} // Good: No documentation needed
+
+  /// Processes data and returns result
+  String processData(String input) {
+    return 'processed';
+  } // Good: Public method documented
+}
+
+// Good: Public methods with documentation, private methods without
+class NetworkService {
+  void _makeRequest() {} // Good: No documentation needed
+  void _handleResponse() {} // Good: No documentation needed
+  void _logError() {} // Good: No documentation needed
+
+  /// Makes HTTP GET request to the specified URL
+  Future<String> get(String url) async {
+    return 'response';
+  }
+
+  /// Makes HTTP POST request with the provided data
+  Future<String> post(String url, Map<String, dynamic> data) async {
+    return 'response';
+  }
+}
+
+// Good: Private fields and variables are ignored (no lint)
+class ConfigService {
+  /// Internal configuration data
+  Map<String, dynamic> _config = {}; // Good: Fields can have documentation
+
+  /// Internal cache
+  final Map<String, String> _cache = {}; // Good: Fields can have documentation
+
+  void _loadConfig() {} // Good: No documentation needed
+
+  /// Loads configuration from external source
+  Future<void> loadConfiguration() async {}
+}
+
+// Good: Private getters and setters are ignored (no lint)
+class StateService {
+  /// Internal state getter
+  bool get _isInitialized => true; // Good: Getters can have documentation
+
+  /// Internal state setter
+  set _isInitialized(bool value) {} // Good: Setters can have documentation
+
+  void _initialize() {} // Good: No documentation needed
+
+  /// Initializes the service
+  Future<void> initialize() async {}
+}
+
+// Good: /** */ comments are ignored (no lint)
+class LogService {
+  /** Handles internal logging */
+  void _logMessage(String message) {} // Good: /** */ comments are allowed
+
+  void _formatMessage() {} // Good: No documentation needed
+
+  /// Logs a message with the specified level
+  void log(String message, String level) {}
+}
+
+// Good: Empty documentation comments are ignored (no lint)
+class CacheService {
+  ///
+  void _clearCache() {} // Good: Empty documentation is allowed
+
+  //
+  void _validateCache() {} // Good: Empty documentation is allowed
+
+  /// Clears all cached data
+  void clearCache() {}
+}

--- a/lib/rules/no_internal_method_docs.dart
+++ b/lib/rules/no_internal_method_docs.dart
@@ -1,0 +1,146 @@
+import 'dart:convert';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/error/error.dart' hide LintCode;
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:analyzer/source/line_info.dart';
+
+/// A lint rule that forbids documentation on private methods to reduce documentation noise.
+///
+/// This rule flags private methods that have documentation comments, as these are
+/// internal implementation details that don't need to be documented for external
+/// consumers. This reduces documentation noise and focuses on public API documentation.
+///
+/// Example of code that triggers this rule:
+/// ```dart
+/// /// Handles internal auth state
+/// void _handleAuthState() { ... }  // LINT: Private method should not be documented
+///
+/// // Validates user input
+/// void _validateInput(String input) { ... }  // LINT: Private method should not be documented
+/// ```
+///
+/// Example of code that doesn't trigger this rule:
+/// ```dart
+/// void _handleAuthState() { ... }  // No documentation - good
+///
+/// /// Public method that should be documented
+/// void authenticate() { ... }  // Public method - documentation required
+/// ```
+class NoInternalMethodDocs extends DartLintRule {
+  const NoInternalMethodDocs() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'no_internal_method_docs',
+    problemMessage: 'Private methods should not have documentation comments.',
+    correctionMessage:
+        'Remove the documentation comment from the private method.',
+    errorSeverity: ErrorSeverity.WARNING,
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addCompilationUnit((node) {
+      if (_isTestFile(resolver.path)) return;
+      _checkForPrivateMethodDocs(node, reporter, resolver);
+    });
+  }
+
+  bool _isTestFile(String path) {
+    return path.contains('_test.dart') ||
+        path.contains('/test/') ||
+        path.contains('/example/') ||
+        path.contains('example_');
+  }
+
+  void _checkForPrivateMethodDocs(
+    CompilationUnit node,
+    ErrorReporter reporter,
+    CustomLintResolver resolver,
+  ) {
+    final visitor = _PrivateMethodDocsVisitor(
+      reporter,
+      node.lineInfo,
+      resolver,
+      node,
+    );
+    node.accept(visitor);
+  }
+}
+
+class _PrivateMethodDocsVisitor extends RecursiveAstVisitor<void> {
+  _PrivateMethodDocsVisitor(
+    this.reporter,
+    this.lineInfo,
+    this.resolver,
+    this.unit,
+  );
+
+  final ErrorReporter reporter;
+  final LineInfo lineInfo;
+  final CustomLintResolver resolver;
+  final CompilationUnit unit;
+
+  @override
+  void visitMethodDeclaration(MethodDeclaration node) {
+    // Only check private methods (starting with _)
+    if (!node.name.lexeme.startsWith('_')) return;
+    // Skip getters and setters
+    if (node.isGetter || node.isSetter) return;
+
+    // Check for /// documentation
+    if (_hasDocumentation(node.documentationComment)) {
+      reporter.atNode(node, NoInternalMethodDocs._code);
+      super.visitMethodDeclaration(node);
+      return;
+    }
+
+    // Best-effort: Check for // comments immediately above the method in the source
+    final methodOffset = node.offset;
+    final methodLine = lineInfo.getLocation(methodOffset).lineNumber;
+    final source = unit.toSource();
+    final lines = const LineSplitter().convert(source);
+    if (methodLine > 1 && methodLine <= lines.length) {
+      int checkLine = methodLine - 2; // Dart lines are 1-based
+      bool found = false;
+      while (checkLine >= 0 && checkLine < lines.length) {
+        final line = lines[checkLine].trimLeft();
+        if (line.startsWith('//')) {
+          // Only flag if the comment is directly above (no blank lines)
+          found = true;
+          checkLine--;
+        } else if (line.isEmpty) {
+          // Stop if there's a blank line
+          break;
+        } else {
+          break;
+        }
+      }
+      if (found) {
+        reporter.atNode(node, NoInternalMethodDocs._code);
+      }
+    }
+
+    super.visitMethodDeclaration(node);
+  }
+
+  bool _hasDocumentation(Comment? comment) {
+    if (comment == null) return false;
+    for (final token in comment.tokens) {
+      final lexeme = token.lexeme;
+      if (lexeme.startsWith('///')) {
+        final content = lexeme.substring(3).trim();
+        if (content.isNotEmpty) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/test/rules/no_internal_method_docs_test.dart
+++ b/test/rules/no_internal_method_docs_test.dart
@@ -1,0 +1,244 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/source/line_info.dart';
+import 'package:analyzer/source/source.dart';
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:ripplearc_flutter_lint/rules/no_internal_method_docs.dart';
+import 'package:test/test.dart';
+import '../utils/test_error_reporter.dart';
+
+void main() {
+  group('NoInternalMethodDocs', () {
+    late NoInternalMethodDocs rule;
+    late TestErrorReporter reporter;
+    late CompilationUnit unit;
+
+    setUp(() {
+      rule = const NoInternalMethodDocs();
+      reporter = TestErrorReporter();
+    });
+
+    Future<void> analyzeCode(String sourceCode, {required String path}) async {
+      final parseResult = parseString(content: sourceCode);
+      unit = parseResult.unit;
+      rule.run(
+        TestCustomLintResolver(unit, path),
+        reporter,
+        TestCustomLintContext(unit),
+      );
+    }
+
+    test('should flag private method with /// documentation', () async {
+      const source = '''
+      class AuthService {
+        /// Handles internal auth state
+        void _handleAuthState() { }
+        
+        void authenticate() { }
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/auth_service.dart');
+      expect(reporter.errors, hasLength(1));
+      expect(
+        reporter.errors.first.errorCode.name,
+        equals('no_internal_method_docs'),
+      );
+    });
+
+    test('should flag multiple private methods with documentation', () async {
+      const source = '''
+      class AuthService {
+        /// Handles internal auth state
+        void _handleAuthState() { }
+        
+        /// Processes user data
+        void _processUserData() { }
+        
+        void authenticate() { }
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/auth_service.dart');
+      expect(reporter.errors, hasLength(2));
+      expect(
+        reporter.errors.first.errorCode.name,
+        equals('no_internal_method_docs'),
+      );
+      expect(
+        reporter.errors.last.errorCode.name,
+        equals('no_internal_method_docs'),
+      );
+    });
+
+    test('should not flag private methods without documentation', () async {
+      const source = '''
+      class AuthService {
+        void _handleAuthState() { }
+        void _validateInput(String input) { }
+        void _processUserData() { }
+        
+        void authenticate() { }
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/auth_service.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag public methods with documentation', () async {
+      const source = '''
+      class AuthService {
+        void _handleAuthState() { }
+        
+        /// Authenticates the user with provided credentials
+        void authenticate() { }
+        
+        /// Logs out the current user
+        void logout() { }
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/auth_service.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag private methods with empty documentation', () async {
+      const source = '''
+      class AuthService {
+        /// 
+        void _handleAuthState() { }
+        
+        // 
+        void _validateInput(String input) { }
+        
+        void authenticate() { }
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/auth_service.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag private methods in test files', () async {
+      const source = '''
+      class AuthService {
+        /// Handles internal auth state
+        void _handleAuthState() { }
+        
+        void authenticate() { }
+      }
+      ''';
+      await analyzeCode(source, path: 'test/auth_service_test.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag private methods in example files', () async {
+      const source = '''
+      class AuthService {
+        /// Handles internal auth state
+        void _handleAuthState() { }
+        
+        void authenticate() { }
+      }
+      ''';
+      await analyzeCode(source, path: 'example/example_auth_service.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag private fields or variables', () async {
+      const source = '''
+      class AuthService {
+        /// Internal auth state
+        bool _isAuthenticated = false;
+        
+        /// User data
+        String _userData = '';
+        
+        void authenticate() { }
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/auth_service.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag private getters and setters', () async {
+      const source = '''
+      class AuthService {
+        /// Internal auth state getter
+        bool get _isAuthenticated => true;
+        
+        /// Internal auth state setter
+        set _isAuthenticated(bool value) { }
+        
+        void authenticate() { }
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/auth_service.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag /** */ documentation comments', () async {
+      const source = '''
+      class AuthService {
+        /** Handles internal auth state */
+        void _handleAuthState() { }
+        
+        void authenticate() { }
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/auth_service.dart');
+      expect(reporter.errors, isEmpty);
+    });
+  });
+}
+
+class TestCustomLintResolver implements CustomLintResolver {
+  TestCustomLintResolver(this.unit, this.path);
+  final CompilationUnit unit;
+  @override
+  final String path;
+
+  @override
+  Future<ResolvedUnitResult> getResolvedUnitResult() async {
+    throw UnimplementedError();
+  }
+
+  @override
+  LineInfo get lineInfo => throw UnimplementedError();
+
+  @override
+  Source get source => throw UnimplementedError();
+}
+
+class _MockLintRuleNodeRegistry implements LintRuleNodeRegistry {
+  final CompilationUnit unit;
+
+  _MockLintRuleNodeRegistry(this.unit);
+
+  @override
+  void addCompilationUnit(Function(CompilationUnit) callback) {
+    callback(unit);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => throw UnimplementedError();
+}
+
+class TestCustomLintContext implements CustomLintContext {
+  TestCustomLintContext(this.unit);
+  final CompilationUnit unit;
+
+  void addCompilationUnit(Function(CompilationUnit) callback) {
+    callback(unit);
+  }
+
+  @override
+  void addPostRunCallback(Function() callback) {}
+
+  @override
+  Pubspec get pubspec => throw UnimplementedError();
+
+  @override
+  Map<String, dynamic> get sharedState => {};
+
+  @override
+  LintRuleNodeRegistry get registry => _MockLintRuleNodeRegistry(unit);
+}


### PR DESCRIPTION
Adds a new lint rule that forbids documentation comments on private methods to reduce documentation noise and focus on public API documentation.

Why This Rule?
Private methods are internal implementation details that don't need to be documented for external consumers. Having documentation on private methods creates noise and makes it harder to focus on the important public API documentation. This rule encourages developers to keep documentation focused on public interfaces while allowing private implementation details to remain undocumented.

Changes
Added NoInternalMethodDocs rule to detect documentation comments on private methods Added comprehensive test suite covering various scenarios (/// comments, // comments, public methods, getters/setters) Added example file demonstrating violations and correct usage patterns Rule only applies to private methods (starting with ) Excludes getters and setters from the rule scope
Excludes test and example files following existing patterns Set severity to WARNING to encourage best practices without being too strict

Technical Details
Uses RecursiveAstVisitor to traverse AST and identify private methods Robustly detects /// documentation comments via AST analysis Best-effort detection of // comments by scanning source lines above methods Includes bounds checking to prevent errors when scanning source lines Reports one error per private method that has documentation Follows existing rule architecture and testing patterns

Benefits
Reduces documentation noise by focusing on public API Encourages cleaner, more maintainable code
Makes public documentation more prominent and easier to find Maintains consistency in documentation practices across the codebase Helps developers focus on documenting what matters most

Documentation Types Detected
/// comments (robust AST-based detection)
// comments (best-effort source scanning)