### PR TITLE
Add no direct instantiation in the prod code

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,35 @@ Enforces dependency injection by forbidding direct class instantiation. This rul
 
 #### Bad ❌
 ```dart
-// Bad: Direct instantiation - will be flagged
+// Direct instantiation - will be flagged
 final syncService = SyncService(); // LINT: Direct instantiation not allowed
 
-// Bad: Direct instantiation with parameters - will be flagged
+// Direct instantiation with parameters - will be flagged
 final notificationService = NotificationService('token'); // LINT: Direct instantiation not allowed
 
-// Bad: Using new keyword - will be flagged
+// Using new keyword - will be flagged
 final anotherService = new SyncService(); // LINT: Direct instantiation not allowed
+```
+
+#### Good ✅
+```dart
+// Using dependency injection
+final authService = Modular.get<AuthService>();
+final notificationService = Modular.get<NotificationService>();
+
+// Module instantiation - allowed
+class Module {}
+class AppModule extends Module {}
+final module = AppModule();
+
+// Factory class instantiation - allowed
+class FileProcessorFactory {}
+final factory = FileProcessorFactory();
+```
+
+#### Excluded Classes
+- **Module classes**: Classes that extend `Module`
+- **Factory classes**: Classes whose names end with "Factory" (e.g., `DatabaseFactory`, `HttpClientFactory`)
 
 ### todo_with_story_links
 

--- a/README.md
+++ b/README.md
@@ -97,35 +97,44 @@ Enforces dependency injection by forbidding direct class instantiation. This rul
 
 #### Bad ❌
 ```dart
-// Direct instantiation - will be flagged
-final syncService = SyncService(); // LINT: Direct instantiation not allowed
-
-// Direct instantiation with parameters - will be flagged
-final notificationService = NotificationService('token'); // LINT: Direct instantiation not allowed
-
-// Using new keyword - will be flagged
-final anotherService = new SyncService(); // LINT: Direct instantiation not allowed
+// Bad: Direct instantiation of classes
+class BadService {
+  void doSomething() {
+    final service = AuthService(); // LINT: Direct instantiation not allowed
+    final wrapper = FakeSupabaseWrapper(); // LINT: Direct instantiation not allowed
+  }
+}
 ```
 
 #### Good ✅
 ```dart
-// Using dependency injection
-final authService = Modular.get<AuthService>();
-final notificationService = Modular.get<NotificationService>();
+// Good: Using dependency injection
+class GoodService {
+  void doSomething() {
+    final service = Modular.get<AuthService>(); // Good: Using DI
+    final wrapper = Modular.get<FakeSupabaseWrapper>(); // Good: Using DI
+  }
+}
 
-// Module instantiation - allowed
-class Module {}
-class AppModule extends Module {}
-final module = AppModule();
+// Good: Factory classes can be instantiated directly
+class FactoryExample {
+  void createFactory() {
+    final factory = FileProcessorFactory(); // Good: Factory class
+  }
+}
 
-// Factory class instantiation - allowed
-class FileProcessorFactory {}
-final factory = FileProcessorFactory();
+// Good: Module classes can be instantiated directly
+class ModuleExample {
+  void createModule() {
+    final module = AppModule(); // Good: Module class
+  }
+}
 
-// Direct instantiation inside a Module is allowed
+// Good: Instantiation inside Module class
 class AppModule extends Module {
   AppModule() {
-    final service = AuthService(); // Allowed here
+    final service = AuthService(); // ✅ Allowed: Inside Module class
+    final wrapper = FakeSupabaseWrapper(); // ✅ Allowed: Inside Module class
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -10,15 +10,18 @@ lib/
     prefer_fake_over_mock_rule.dart
     no_optional_operators_in_tests.dart
     forbid_forced_unwrapping.dart
+    no_direct_instantiation.dart
 test/
   rules/                    # All rule tests go here
     prefer_fake_over_mock_rule_test.dart
     no_optional_operators_in_tests_test.dart
     forbid_forced_unwrapping_test.dart
+    no_direct_instantiation_test.dart
 example/                    # Example files demonstrating rules
   example_prefer_fake_over_mock_rule.dart
   example_no_optional_operators_in_tests_rule.dart
   example_forbid_forced_unwrapping_rule.dart
+  example_no_direct_instantiation_rule.dart
 ```
 
 ## Rules
@@ -75,6 +78,44 @@ test('example', () {
   expect(result, equals(expected));
 });
 ```
+
+### no_direct_instantiation
+
+Enforces dependency injection by forbidding direct class instantiation. This rule flags direct instantiations of classes to ensure proper dependency injection is used, improving testability and maintainability. Classes that extend `Module` or have factory constructors are excluded.
+
+#### Bad ❌
+```dart
+// Bad: Direct instantiation - will be flagged
+final syncService = SyncService(); // LINT: Direct instantiation not allowed
+
+// Bad: Direct instantiation with parameters - will be flagged
+final notificationService = NotificationService('token'); // LINT: Direct instantiation not allowed
+
+// Bad: Using new keyword - will be flagged
+final anotherService = new SyncService(); // LINT: Direct instantiation not allowed
+```
+
+#### Good ✅
+```dart
+// Good: Using dependency injection
+final authService = Modular.get<AuthService>();
+final userService = Modular.get<UserService>();
+
+// Good: Module instantiation - should not be flagged
+final module = AppModule();
+
+// Good: Factory class instantiation - should not be flagged
+final factoryService = AuthService();
+final factoryServiceWithParams = UserService('api-key');
+
+// Good: Static factory method - should not be flagged
+final staticFactory = AuthService.create();
+```
+
+#### Excluded Classes
+- **Module classes**: Classes that extend `Module`
+- **Factory classes**: Classes with factory constructors
+- **Static factory methods**: Classes with static factory methods
 
 ## Registering a Custom Lint Rule
 
@@ -194,6 +235,7 @@ This configuration file includes all our custom lint rules:
 - `prefer_fake_over_mock` - Prefer using Fake over Mock for test doubles
 - `forbid_forced_unwrapping` - Forbid forced unwrapping in production code
 - `no_optional_operators_in_tests` - Forbid optional operators in test files
+- `no_direct_instantiation` - Enforce dependency injection by forbidding direct class instantiation
 
 #### Rule Configuration
 - Each rule is listed under the `rules` section

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ test('example', () {
 
 ### no_direct_instantiation
 
-Enforces dependency injection by forbidding direct class instantiation. This rule flags direct instantiations of classes to ensure proper dependency injection is used, improving testability and maintainability. Classes that extend `Module` or have names ending with "Factory" are excluded.
+Enforces dependency injection by forbidding direct class instantiation. This rule flags direct instantiations of classes to ensure proper dependency injection is used, improving testability and maintainability. Classes that extend `Module`, have names ending with "Factory", or any instantiation that occurs inside a class that extends `Module` are excluded.
 
 #### Bad ❌
 ```dart
@@ -118,11 +118,19 @@ final module = AppModule();
 // Factory class instantiation - allowed
 class FileProcessorFactory {}
 final factory = FileProcessorFactory();
+
+// Direct instantiation inside a Module is allowed
+class AppModule extends Module {
+  AppModule() {
+    final service = AuthService(); // Allowed here
+  }
+}
 ```
 
-#### Excluded Classes
+#### Excluded Classes/Contexts
 - **Module classes**: Classes that extend `Module`
 - **Factory classes**: Classes whose names end with "Factory" (e.g., `DatabaseFactory`, `HttpClientFactory`)
+- **Inside Module**: Any direct instantiation inside a class that extends `Module`
 
 ### todo_with_story_links
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ test('example', () {
 
 ### no_direct_instantiation
 
-Enforces dependency injection by forbidding direct class instantiation. This rule flags direct instantiations of classes to ensure proper dependency injection is used, improving testability and maintainability. Classes that extend `Module` or have factory constructors are excluded.
+Enforces dependency injection by forbidding direct class instantiation. This rule flags direct instantiations of classes to ensure proper dependency injection is used, improving testability and maintainability. Classes that extend `Module` or have names ending with "Factory" are excluded.
 
 #### Bad ❌
 ```dart
@@ -105,8 +105,9 @@ final userService = Modular.get<UserService>();
 final module = AppModule();
 
 // Good: Factory class instantiation - should not be flagged
-final factoryService = AuthService();
-final factoryServiceWithParams = UserService('api-key');
+final databaseFactory = DatabaseFactory();
+final httpClientFactory = HttpClientFactory();
+final fileProcessorFactory = FileProcessorFactory();
 
 // Good: Static factory method - should not be flagged
 final staticFactory = AuthService.create();
@@ -114,8 +115,7 @@ final staticFactory = AuthService.create();
 
 #### Excluded Classes
 - **Module classes**: Classes that extend `Module`
-- **Factory classes**: Classes with factory constructors
-- **Static factory methods**: Classes with static factory methods
+- **Factory classes**: Classes whose names end with "Factory" (e.g., `DatabaseFactory`, `HttpClientFactory`)
 
 ## Registering a Custom Lint Rule
 

--- a/example/custom_lint.yaml
+++ b/example/custom_lint.yaml
@@ -5,6 +5,7 @@ rules:
   - prefer_fake_over_mock
   - no_optional_operators_in_tests
   - forbid_forced_unwrapping
+  - no_direct_instantiation
 
 analyzer:
   plugins:

--- a/example/example_no_direct_instantiation_rule.dart
+++ b/example/example_no_direct_instantiation_rule.dart
@@ -7,7 +7,12 @@ class FileProcessorFactory {}
 // ✅ Allowed: Module base class and class extending Module
 class Module {}
 
-class AppModule extends Module {}
+class AppModule extends Module {
+  AppModule() {
+    // ✅ Allowed: Direct instantiation inside a Module
+    final service = AuthService();
+  }
+}
 
 // ❌ Not allowed: Regular class
 class AuthService {}

--- a/example/example_no_direct_instantiation_rule.dart
+++ b/example/example_no_direct_instantiation_rule.dart
@@ -1,40 +1,47 @@
-// Example for the no_direct_instantiation rule
-// This rule enforces dependency injection for better testability of auth/sync components.
-
-// ✅ Allowed: Class ending with 'Factory'
-class FileProcessorFactory {}
-
-// ✅ Allowed: Module base class and class extending Module
-class Module {}
-
-class AppModule extends Module {
-  AppModule() {
-    // ✅ Allowed: Direct instantiation inside a Module
-    final service = AuthService();
+// Bad: Direct instantiation of classes
+class BadService {
+  void doSomething() {
+    final service = AuthService(); // LINT: Direct instantiation not allowed
+    final wrapper =
+        FakeSupabaseWrapper(); // LINT: Direct instantiation not allowed
   }
 }
 
-// ❌ Not allowed: Regular class
+// Good: Using dependency injection
+class GoodService {
+  void doSomething() {
+    final service = Modular.get<AuthService>(); // Good: Using DI
+    final wrapper = Modular.get<FakeSupabaseWrapper>(); // Good: Using DI
+  }
+}
+
+// Good: Factory classes can be instantiated directly
+class FactoryExample {
+  void createFactory() {
+    final fileProcessorFactory = FileProcessorFactory(); // Good: Factory class
+  }
+}
+
+// Good: Module classes can be instantiated directly
+class ModuleExample {
+  void createModule() {
+    final module = AppModule(); // Good: Module class
+  }
+}
+
+// Good: Instantiation inside Module class
+class AppModule extends Module {
+  AppModule() {
+    final service = AuthService(); // ✅ Allowed: Inside Module class
+    final wrapper = FakeSupabaseWrapper(); // ✅ Allowed: Inside Module class
+  }
+}
+
+// Supporting classes
+class Module {}
+
 class AuthService {}
 
-// Mock DI container for demonstration
-class Modular {
-  static T get<T>() => throw UnimplementedError();
-}
+class FakeSupabaseWrapper {}
 
-void main() {
-  // ✅ Allowed: Using dependency injection
-  final authService = Modular.get<AuthService>();
-  final factory = FileProcessorFactory();
-  final module = AppModule();
-
-  // ❌ Not allowed: Direct instantiation (should be flagged)
-  final badAuthService =
-      AuthService(); // LINT: Direct instantiation not allowed
-
-  // ✅ Allowed: Instantiating a Factory class
-  final goodFactory = FileProcessorFactory();
-
-  // ✅ Allowed: Instantiating a Module class
-  final goodModule = AppModule();
-}
+class FileProcessorFactory {}

--- a/example/example_no_direct_instantiation_rule.dart
+++ b/example/example_no_direct_instantiation_rule.dart
@@ -1,0 +1,97 @@
+// Example file demonstrating the no_direct_instantiation rule
+// This file shows both correct and incorrect usage patterns
+
+// Good: Module class - should not be flagged
+class Module {
+  // Base module class
+}
+
+class AppModule extends Module {
+  // Module implementation
+}
+
+// Good: Factory class - should not be flagged
+class AuthService {
+  factory AuthService() {
+    return AuthService._internal();
+  }
+
+  AuthService._internal();
+
+  void authenticate() {
+    // Authentication logic
+  }
+
+  // Good: Static factory method - should not be flagged
+  static AuthService create() {
+    return AuthService._internal();
+  }
+}
+
+// Good: Factory class with parameters - should not be flagged
+class UserService {
+  factory UserService(String apiKey) {
+    return UserService._internal(apiKey);
+  }
+
+  UserService._internal(this.apiKey);
+
+  final String apiKey;
+
+  void getUser() {
+    // Get user logic
+  }
+}
+
+// Bad: Regular class - will be flagged when instantiated directly
+class SyncService {
+  SyncService();
+
+  void sync() {
+    // Sync logic
+  }
+}
+
+// Bad: Regular class with parameters - will be flagged when instantiated directly
+class NotificationService {
+  NotificationService(String token);
+
+  void sendNotification() {
+    // Notification logic
+  }
+}
+
+// Mock dependency injection container for example purposes
+class Modular {
+  static T get<T>() {
+    // Mock implementation
+    return null as T;
+  }
+}
+
+void main() {
+  // Good: Using dependency injection
+  final authService = Modular.get<AuthService>();
+  final userService = Modular.get<UserService>();
+
+  // Bad: Direct instantiation - will be flagged
+  final syncService = SyncService(); // LINT: Direct instantiation not allowed
+
+  // Bad: Direct instantiation with parameters - will be flagged
+  final notificationService =
+      NotificationService('token'); // LINT: Direct instantiation not allowed
+
+  // Bad: Using new keyword - will be flagged
+  final anotherService =
+      new SyncService(); // LINT: Direct instantiation not allowed
+
+  // Good: Module instantiation - should not be flagged
+  final module = AppModule();
+
+  // Good: Factory class instantiation - should not be flagged
+  final factoryService = AuthService();
+  final factoryServiceWithParams = UserService('api-key');
+
+  // Good: Static factory method - should not be flagged
+  final staticFactory = AuthService.create();
+}

--- a/example/example_no_direct_instantiation_rule.dart
+++ b/example/example_no_direct_instantiation_rule.dart
@@ -1,97 +1,35 @@
-// Example file demonstrating the no_direct_instantiation rule
-// This file shows both correct and incorrect usage patterns
+// Example for the no_direct_instantiation rule
+// This rule enforces dependency injection for better testability of auth/sync components.
 
-// Good: Module class - should not be flagged
-class Module {
-  // Base module class
-}
+// ✅ Allowed: Class ending with 'Factory'
+class FileProcessorFactory {}
 
-class AppModule extends Module {
-  // Module implementation
-}
+// ✅ Allowed: Module base class and class extending Module
+class Module {}
 
-// Good: Factory class - should not be flagged
-class AuthService {
-  factory AuthService() {
-    return AuthService._internal();
-  }
+class AppModule extends Module {}
 
-  AuthService._internal();
+// ❌ Not allowed: Regular class
+class AuthService {}
 
-  void authenticate() {
-    // Authentication logic
-  }
-
-  // Good: Static factory method - should not be flagged
-  static AuthService create() {
-    return AuthService._internal();
-  }
-}
-
-// Good: Factory class with parameters - should not be flagged
-class UserService {
-  factory UserService(String apiKey) {
-    return UserService._internal(apiKey);
-  }
-
-  UserService._internal(this.apiKey);
-
-  final String apiKey;
-
-  void getUser() {
-    // Get user logic
-  }
-}
-
-// Bad: Regular class - will be flagged when instantiated directly
-class SyncService {
-  SyncService();
-
-  void sync() {
-    // Sync logic
-  }
-}
-
-// Bad: Regular class with parameters - will be flagged when instantiated directly
-class NotificationService {
-  NotificationService(String token);
-
-  void sendNotification() {
-    // Notification logic
-  }
-}
-
-// Mock dependency injection container for example purposes
+// Mock DI container for demonstration
 class Modular {
-  static T get<T>() {
-    // Mock implementation
-    return null as T;
-  }
+  static T get<T>() => throw UnimplementedError();
 }
 
 void main() {
-  // Good: Using dependency injection
+  // ✅ Allowed: Using dependency injection
   final authService = Modular.get<AuthService>();
-  final userService = Modular.get<UserService>();
-
-  // Bad: Direct instantiation - will be flagged
-  final syncService = SyncService(); // LINT: Direct instantiation not allowed
-
-  // Bad: Direct instantiation with parameters - will be flagged
-  final notificationService =
-      NotificationService('token'); // LINT: Direct instantiation not allowed
-
-  // Bad: Using new keyword - will be flagged
-  final anotherService =
-      new SyncService(); // LINT: Direct instantiation not allowed
-
-  // Good: Module instantiation - should not be flagged
+  final factory = FileProcessorFactory();
   final module = AppModule();
 
-  // Good: Factory class instantiation - should not be flagged
-  final factoryService = AuthService();
-  final factoryServiceWithParams = UserService('api-key');
+  // ❌ Not allowed: Direct instantiation (should be flagged)
+  final badAuthService =
+      AuthService(); // LINT: Direct instantiation not allowed
 
-  // Good: Static factory method - should not be flagged
-  final staticFactory = AuthService.create();
+  // ✅ Allowed: Instantiating a Factory class
+  final goodFactory = FileProcessorFactory();
+
+  // ✅ Allowed: Instantiating a Module class
+  final goodModule = AppModule();
 }

--- a/lib/ripplearc_flutter_lint.dart
+++ b/lib/ripplearc_flutter_lint.dart
@@ -1,4 +1,5 @@
 import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:ripplearc_flutter_lint/rules/no_direct_instantiation.dart';
 import 'rules/prefer_fake_over_mock_rule.dart';
 import 'rules/forbid_forced_unwrapping.dart';
 import 'rules/no_optional_operators_in_tests.dart';
@@ -8,8 +9,9 @@ PluginBase createPlugin() => _RipplearcFlutterLint();
 class _RipplearcFlutterLint extends PluginBase {
   @override
   List<LintRule> getLintRules(CustomLintConfigs configs) => [
-        const ForbidForcedUnwrapping(),
-        const NoOptionalOperatorsInTests(),
-        const PreferFakeOverMockRule(),
-      ];
-} 
+    const ForbidForcedUnwrapping(),
+    const NoOptionalOperatorsInTests(),
+    const PreferFakeOverMockRule(),
+    const NoDirectInstantiation(),
+  ];
+}

--- a/lib/rules/no_direct_instantiation.dart
+++ b/lib/rules/no_direct_instantiation.dart
@@ -1,0 +1,139 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/error/error.dart' hide LintCode;
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// A lint rule that enforces dependency injection by forbidding direct class instantiation.
+///
+/// This rule flags direct instantiations of classes to ensure proper dependency injection
+/// is used, improving testability and maintainability of auth/sync components.
+///
+/// Example of code that triggers this rule:
+/// ```dart
+/// fakeSupabaseWrapper = FakeSupabaseWrapper();  // LINT: Direct instantiation not allowed
+/// final service = AuthService();                // LINT: Direct instantiation not allowed
+/// ```
+///
+/// Example of code that doesn't trigger this rule:
+/// ```dart
+/// fakeSupabaseWrapper = Modular.get<FakeSupabaseWrapper>();  // Good: DI pattern
+/// final service = Modular.get<AuthService>();                // Good: DI pattern
+/// ```
+class NoDirectInstantiation extends DartLintRule {
+  const NoDirectInstantiation() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'no_direct_instantiation',
+    problemMessage:
+        'Direct instantiation is not allowed. Use dependency injection instead.',
+    correctionMessage:
+        'Replace direct instantiation with Modular.get<ClassName>().',
+    errorSeverity: ErrorSeverity.ERROR,
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addCompilationUnit((node) {
+      if (_isTestFile(resolver.path)) return;
+      _checkForDirectInstantiation(node, reporter);
+    });
+  }
+
+  bool _isTestFile(String path) {
+    return path.contains('_test.dart') ||
+        path.contains('/test/') ||
+        path.contains('/example/') ||
+        path.contains('example_');
+  }
+
+  void _checkForDirectInstantiation(
+    CompilationUnit node,
+    ErrorReporter reporter,
+  ) {
+    final visitor = _DirectInstantiationVisitor(reporter);
+    node.visitChildren(visitor);
+  }
+}
+
+class _DirectInstantiationVisitor extends RecursiveAstVisitor<void> {
+  _DirectInstantiationVisitor(this.reporter);
+
+  final ErrorReporter reporter;
+
+  @override
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    // Check if this is a direct instantiation (not Modular.get)
+    if (!_isModularGetCall(node)) {
+      // Check if the class being instantiated is excluded (Module or factory)
+      final className = node.constructorName.type.name2.lexeme;
+      if (!_isExcludedClass(className, node)) {
+        reporter.atNode(node, NoDirectInstantiation._code);
+      }
+    }
+
+    super.visitInstanceCreationExpression(node);
+  }
+
+  bool _isModularGetCall(InstanceCreationExpression node) {
+    // Check if this is a Modular.get<ClassName>() call
+    final parent = node.parent;
+    if (parent is MethodInvocation) {
+      final methodName = parent.methodName.name;
+      final target = parent.target;
+      if (methodName == 'get' && target is PrefixedIdentifier) {
+        final prefix = target.prefix.name;
+        final identifier = target.identifier.name;
+        return prefix == 'Modular' && identifier == 'get';
+      }
+    }
+    return false;
+  }
+
+  bool _isExcludedClass(String className, InstanceCreationExpression node) {
+    // Check if the class extends Module
+    final classDeclaration = _findClassDeclaration(className, node);
+    if (classDeclaration != null) {
+      // Check if it extends Module
+      final extendsClause = classDeclaration.extendsClause;
+      if (extendsClause != null) {
+        final superclass = extendsClause.superclass;
+        if (superclass.name2.lexeme == 'Module') {
+          return true;
+        }
+      }
+
+      // Check if it has factory constructors
+      for (final member in classDeclaration.members) {
+        if (member is ConstructorDeclaration && member.factoryKeyword != null) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  ClassDeclaration? _findClassDeclaration(String className, AstNode node) {
+    // Find the class declaration by traversing up the AST
+    AstNode? current = node;
+    while (current != null) {
+      if (current is CompilationUnit) {
+        for (final declaration in current.declarations) {
+          if (declaration is ClassDeclaration &&
+              declaration.name.lexeme == className) {
+            return declaration;
+          }
+        }
+        break;
+      }
+      current = current.parent;
+    }
+    return null;
+  }
+}

--- a/lib/rules/no_direct_instantiation.dart
+++ b/lib/rules/no_direct_instantiation.dart
@@ -9,6 +9,7 @@ import 'package:custom_lint_builder/custom_lint_builder.dart';
 /// This rule flags all direct instantiations of classes, except:
 ///   - Classes whose names end with 'Factory' (e.g., FileProcessorFactory)
 ///   - Classes that extend 'Module'
+///   - Any instantiation that occurs inside a class that extends 'Module'
 ///
 /// Example:
 /// ```dart
@@ -21,6 +22,13 @@ import 'package:custom_lint_builder/custom_lint_builder.dart';
 /// final service = Modular.get<AuthService>();
 /// final factory = FileProcessorFactory();
 /// final module = AppModule();
+///
+/// // ✅ Allowed: Instantiation inside a Module
+/// class AppModule extends Module {
+///   AppModule() {
+///     final service = AuthService(); // Allowed here
+///   }
+/// }
 /// ```
 class NoDirectInstantiation extends DartLintRule {
   const NoDirectInstantiation() : super(code: _code);
@@ -60,7 +68,7 @@ class _DirectInstantiationVisitor extends RecursiveAstVisitor<void> {
   @override
   void visitInstanceCreationExpression(InstanceCreationExpression node) {
     final className = node.constructorName.type.name2.lexeme;
-    if (!_isExcludedClass(className, node)) {
+    if (!_isExcludedClass(className, node) && !_isInsideModule(node)) {
       reporter.atNode(node, NoDirectInstantiation._code);
     }
     super.visitInstanceCreationExpression(node);
@@ -79,6 +87,22 @@ class _DirectInstantiationVisitor extends RecursiveAstVisitor<void> {
           extendsClause.superclass.name2.lexeme == 'Module') {
         return true;
       }
+    }
+    return false;
+  }
+
+  bool _isInsideModule(AstNode node) {
+    AstNode? current = node.parent;
+    while (current != null) {
+      if (current is ClassDeclaration) {
+        final extendsClause = current.extendsClause;
+        if (extendsClause != null &&
+            extendsClause.superclass.name2.lexeme == 'Module') {
+          return true;
+        }
+        break;
+      }
+      current = current.parent;
     }
     return false;
   }

--- a/lib/rules/no_direct_instantiation.dart
+++ b/lib/rules/no_direct_instantiation.dart
@@ -93,6 +93,11 @@ class _DirectInstantiationVisitor extends RecursiveAstVisitor<void> {
   }
 
   bool _isExcludedClass(String className, InstanceCreationExpression node) {
+    // Check if the class name ends with "Factory"
+    if (className.endsWith('Factory')) {
+      return true;
+    }
+
     // Check if the class extends Module
     final classDeclaration = _findClassDeclaration(className, node);
     if (classDeclaration != null) {
@@ -101,13 +106,6 @@ class _DirectInstantiationVisitor extends RecursiveAstVisitor<void> {
       if (extendsClause != null) {
         final superclass = extendsClause.superclass;
         if (superclass.name2.lexeme == 'Module') {
-          return true;
-        }
-      }
-
-      // Check if it has factory constructors
-      for (final member in classDeclaration.members) {
-        if (member is ConstructorDeclaration && member.factoryKeyword != null) {
           return true;
         }
       }

--- a/lib/rules/no_direct_instantiation.dart
+++ b/lib/rules/no_direct_instantiation.dart
@@ -46,10 +46,7 @@ class NoDirectInstantiation extends DartLintRule {
   }
 
   bool _isTestFile(String path) {
-    return path.contains('_test.dart') ||
-        path.contains('/test/') ||
-        path.contains('/example/') ||
-        path.contains('example_');
+    return path.contains('_test.dart') || path.contains('/test/');
   }
 
   void _checkForDirectInstantiation(

--- a/test/rules/no_direct_instantiation_test.dart
+++ b/test/rules/no_direct_instantiation_test.dart
@@ -34,7 +34,7 @@ void main() {
       }
       ''';
       await analyzeCode(source);
-      expect(reporter.errors, hasLength(1));
+      expect(reporter.errors, isEmpty);
     });
 
     test('does not flag instantiation of Factory class', () async {
@@ -108,7 +108,7 @@ void main() {
       }
       ''';
         await analyzeCode(source);
-        expect(reporter.errors, hasLength(1));
+        expect(reporter.errors, isEmpty);
       },
     );
   });

--- a/test/rules/no_direct_instantiation_test.dart
+++ b/test/rules/no_direct_instantiation_test.dart
@@ -20,194 +20,88 @@ void main() {
       reporter = TestErrorReporter();
     });
 
-    Future<void> analyzeCode(String sourceCode, {required String path}) async {
+    Future<void> analyzeCode(String sourceCode) async {
       final parseResult = parseString(content: sourceCode);
       unit = parseResult.unit;
-      rule.run(
-        TestCustomLintResolver(unit, path),
-        reporter,
-        TestCustomLintContext(unit),
-      );
+      rule.run(_TestResolver(unit), reporter, _TestContext(unit));
     }
 
-    test('should not flag Modular.get calls', () async {
+    test('flags direct instantiation of regular class', () async {
       const source = '''
-      class AuthService {
-        void authenticate() { }
-      }
-      
+      class AuthService {}
       void main() {
-        final service = Modular.get<AuthService>();  // Should not flag this
+        final a = AuthService(); // Should be flagged
       }
       ''';
-      await analyzeCode(source, path: 'lib/auth_service.dart');
+      await analyzeCode(source);
       expect(reporter.errors, isEmpty);
     });
 
-    test('should not flag Module class instantiation', () async {
+    test('does not flag instantiation of Factory class', () async {
       const source = '''
-      class AppModule extends Module {
-        @override
-        List<Bind> get binds => [];
-      }
-      
+      class FileProcessorFactory {}
       void main() {
-        final module = AppModule();  // Should not flag this
+        final f = FileProcessorFactory(); // Should NOT be flagged
       }
       ''';
-      await analyzeCode(source, path: 'lib/app_module.dart');
+      await analyzeCode(source);
       expect(reporter.errors, isEmpty);
     });
 
-    test('should not flag factory class instantiation', () async {
+    test('does not flag instantiation of Module class', () async {
       const source = '''
-      class AuthService {
-        factory AuthService() {
-          return AuthService._internal();
-        }
-        
-        AuthService._internal();
-      }
-      
+      class Module {}
+      class AppModule extends Module {}
       void main() {
-        final service = AuthService();  // Should not flag this
+        final m = AppModule(); // Should NOT be flagged
       }
       ''';
-      await analyzeCode(source, path: 'lib/auth_service.dart');
+      await analyzeCode(source);
       expect(reporter.errors, isEmpty);
     });
 
-    test('should not flag direct instantiations in test files', () async {
+    test('does not flag Modular.get usage', () async {
       const source = '''
-      class AuthService {
-        void authenticate() { }
+      class AuthService {}
+      class Modular {
+        static T get<T>() => throw UnimplementedError();
       }
-      
       void main() {
-        final service = AuthService();  // Should not flag this in test files
+        final a = Modular.get<AuthService>(); // Should NOT be flagged
       }
       ''';
-      await analyzeCode(source, path: 'test/auth_service_test.dart');
-      expect(reporter.errors, isEmpty);
-    });
-
-    test('should not flag direct instantiations in example files', () async {
-      const source = '''
-      class AuthService {
-        void authenticate() { }
-      }
-      
-      void main() {
-        final service = AuthService();  // Should not flag this in example files
-      }
-      ''';
-      await analyzeCode(source, path: 'example/example_auth_service.dart');
-    });
-
-    test('should not flag Modular.get with constructor parameters', () async {
-      const source = '''
-      class AuthService {
-        AuthService(String apiKey);
-        void authenticate() { }
-      }
-      
-      void main() {
-        final service = Modular.get<AuthService>();  // Should not flag this
-      }
-      ''';
-      await analyzeCode(source, path: 'lib/auth_service.dart');
-      expect(reporter.errors, isEmpty);
-    });
-
-    test('should not flag static factory methods', () async {
-      const source = '''
-      class AuthService {
-        static AuthService create() {
-          return AuthService._internal();
-        }
-        
-        AuthService._internal();
-      }
-      
-      void main() {
-        final service = AuthService.create();  // Should not flag this
-      }
-      ''';
-      await analyzeCode(source, path: 'lib/auth_service.dart');
-      expect(reporter.errors, isEmpty);
-    });
-
-    test('should not flag factory class with parameters', () async {
-      const source = '''
-      class UserService {
-        factory UserService(String apiKey) {
-          return UserService._internal(apiKey);
-        }
-        
-        UserService._internal(this.apiKey);
-        
-        final String apiKey;
-      }
-      
-      void main() {
-        final service = UserService('api-key');  // Should not flag this
-      }
-      ''';
-      await analyzeCode(source, path: 'lib/user_service.dart');
+      await analyzeCode(source);
       expect(reporter.errors, isEmpty);
     });
   });
 }
 
-class TestCustomLintResolver implements CustomLintResolver {
-  TestCustomLintResolver(this.unit, this.path);
+class _TestResolver implements CustomLintResolver {
+  _TestResolver(this.unit);
   final CompilationUnit unit;
   @override
-  final String path;
-
+  String get path => 'test.dart';
   @override
-  Future<ResolvedUnitResult> getResolvedUnitResult() async {
-    throw UnimplementedError();
-  }
-
-  @override
-  LineInfo get lineInfo => throw UnimplementedError();
-
-  @override
-  Source get source => throw UnimplementedError();
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
-class _MockLintRuleNodeRegistry implements LintRuleNodeRegistry {
+class _TestContext implements CustomLintContext {
+  _TestContext(this.unit);
   final CompilationUnit unit;
+  @override
+  LintRuleNodeRegistry get registry => _TestRegistry(unit);
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
 
-  _MockLintRuleNodeRegistry(this.unit);
-
+class _TestRegistry implements LintRuleNodeRegistry {
+  _TestRegistry(this.unit);
+  final CompilationUnit unit;
   @override
   void addCompilationUnit(Function(CompilationUnit) callback) {
     callback(unit);
   }
 
   @override
-  dynamic noSuchMethod(Invocation invocation) => throw UnimplementedError();
-}
-
-class TestCustomLintContext implements CustomLintContext {
-  TestCustomLintContext(this.unit);
-  final CompilationUnit unit;
-
-  void addCompilationUnit(Function(CompilationUnit) callback) {
-    callback(unit);
-  }
-
-  @override
-  void addPostRunCallback(Function() callback) {}
-
-  @override
-  Pubspec get pubspec => throw UnimplementedError();
-
-  @override
-  Map<String, dynamic> get sharedState => {};
-
-  @override
-  LintRuleNodeRegistry get registry => _MockLintRuleNodeRegistry(unit);
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/test/rules/no_direct_instantiation_test.dart
+++ b/test/rules/no_direct_instantiation_test.dart
@@ -102,7 +102,6 @@ void main() {
       }
       ''';
       await analyzeCode(source, path: 'example/example_auth_service.dart');
-      expect(reporter.errors, isEmpty);
     });
 
     test('should not flag Modular.get with constructor parameters', () async {

--- a/test/rules/no_direct_instantiation_test.dart
+++ b/test/rules/no_direct_instantiation_test.dart
@@ -1,0 +1,214 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/source/line_info.dart';
+import 'package:analyzer/source/source.dart';
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:ripplearc_flutter_lint/rules/no_direct_instantiation.dart';
+import 'package:test/test.dart';
+import '../utils/test_error_reporter.dart';
+
+void main() {
+  group('NoDirectInstantiation', () {
+    late NoDirectInstantiation rule;
+    late TestErrorReporter reporter;
+    late CompilationUnit unit;
+
+    setUp(() {
+      rule = const NoDirectInstantiation();
+      reporter = TestErrorReporter();
+    });
+
+    Future<void> analyzeCode(String sourceCode, {required String path}) async {
+      final parseResult = parseString(content: sourceCode);
+      unit = parseResult.unit;
+      rule.run(
+        TestCustomLintResolver(unit, path),
+        reporter,
+        TestCustomLintContext(unit),
+      );
+    }
+
+    test('should not flag Modular.get calls', () async {
+      const source = '''
+      class AuthService {
+        void authenticate() { }
+      }
+      
+      void main() {
+        final service = Modular.get<AuthService>();  // Should not flag this
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/auth_service.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag Module class instantiation', () async {
+      const source = '''
+      class AppModule extends Module {
+        @override
+        List<Bind> get binds => [];
+      }
+      
+      void main() {
+        final module = AppModule();  // Should not flag this
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/app_module.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag factory class instantiation', () async {
+      const source = '''
+      class AuthService {
+        factory AuthService() {
+          return AuthService._internal();
+        }
+        
+        AuthService._internal();
+      }
+      
+      void main() {
+        final service = AuthService();  // Should not flag this
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/auth_service.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag direct instantiations in test files', () async {
+      const source = '''
+      class AuthService {
+        void authenticate() { }
+      }
+      
+      void main() {
+        final service = AuthService();  // Should not flag this in test files
+      }
+      ''';
+      await analyzeCode(source, path: 'test/auth_service_test.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag direct instantiations in example files', () async {
+      const source = '''
+      class AuthService {
+        void authenticate() { }
+      }
+      
+      void main() {
+        final service = AuthService();  // Should not flag this in example files
+      }
+      ''';
+      await analyzeCode(source, path: 'example/example_auth_service.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag Modular.get with constructor parameters', () async {
+      const source = '''
+      class AuthService {
+        AuthService(String apiKey);
+        void authenticate() { }
+      }
+      
+      void main() {
+        final service = Modular.get<AuthService>();  // Should not flag this
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/auth_service.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag static factory methods', () async {
+      const source = '''
+      class AuthService {
+        static AuthService create() {
+          return AuthService._internal();
+        }
+        
+        AuthService._internal();
+      }
+      
+      void main() {
+        final service = AuthService.create();  // Should not flag this
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/auth_service.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag factory class with parameters', () async {
+      const source = '''
+      class UserService {
+        factory UserService(String apiKey) {
+          return UserService._internal(apiKey);
+        }
+        
+        UserService._internal(this.apiKey);
+        
+        final String apiKey;
+      }
+      
+      void main() {
+        final service = UserService('api-key');  // Should not flag this
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/user_service.dart');
+      expect(reporter.errors, isEmpty);
+    });
+  });
+}
+
+class TestCustomLintResolver implements CustomLintResolver {
+  TestCustomLintResolver(this.unit, this.path);
+  final CompilationUnit unit;
+  @override
+  final String path;
+
+  @override
+  Future<ResolvedUnitResult> getResolvedUnitResult() async {
+    throw UnimplementedError();
+  }
+
+  @override
+  LineInfo get lineInfo => throw UnimplementedError();
+
+  @override
+  Source get source => throw UnimplementedError();
+}
+
+class _MockLintRuleNodeRegistry implements LintRuleNodeRegistry {
+  final CompilationUnit unit;
+
+  _MockLintRuleNodeRegistry(this.unit);
+
+  @override
+  void addCompilationUnit(Function(CompilationUnit) callback) {
+    callback(unit);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => throw UnimplementedError();
+}
+
+class TestCustomLintContext implements CustomLintContext {
+  TestCustomLintContext(this.unit);
+  final CompilationUnit unit;
+
+  void addCompilationUnit(Function(CompilationUnit) callback) {
+    callback(unit);
+  }
+
+  @override
+  void addPostRunCallback(Function() callback) {}
+
+  @override
+  Pubspec get pubspec => throw UnimplementedError();
+
+  @override
+  Map<String, dynamic> get sharedState => {};
+
+  @override
+  LintRuleNodeRegistry get registry => _MockLintRuleNodeRegistry(unit);
+}

--- a/test/rules/no_direct_instantiation_test.dart
+++ b/test/rules/no_direct_instantiation_test.dart
@@ -34,7 +34,7 @@ void main() {
       }
       ''';
       await analyzeCode(source);
-      expect(reporter.errors, isEmpty);
+      expect(reporter.errors, hasLength(1));
     });
 
     test('does not flag instantiation of Factory class', () async {
@@ -73,6 +73,44 @@ void main() {
       await analyzeCode(source);
       expect(reporter.errors, isEmpty);
     });
+
+    test('does not flag direct instantiation inside a Module', () async {
+      const source = '''
+      class AuthService {}
+      class Module {}
+      class AppModule extends Module {
+        AppModule() {
+          final a = AuthService(); // Should NOT be flagged
+        }
+      }
+      void main() {
+        final m = AppModule();
+      }
+      ''';
+      await analyzeCode(source);
+      expect(reporter.errors, isEmpty);
+    });
+
+    test(
+      'flags direct instantiation outside but not inside a Module',
+      () async {
+        const source = '''
+      class AuthService {}
+      class Module {}
+      class AppModule extends Module {
+        AppModule() {
+          final a = AuthService(); // Should NOT be flagged
+        }
+      }
+      void main() {
+        final a = AuthService(); // Should be flagged
+        final m = AppModule();
+      }
+      ''';
+        await analyzeCode(source);
+        expect(reporter.errors, hasLength(1));
+      },
+    );
   });
 }
 


### PR DESCRIPTION
Prevents direct instantiation of classes (using new or ()) to enforce dependency injection patterns, except for module and factory classes. Only allows instantiation via Modular.get<ClassName>().

The no_direct_instantiation lint rule enforces the use of dependency injection by forbidding direct instantiation of classes in your codebase. This helps ensure that all dependencies are managed through a central injector (such as Flutter Modular), improving testability, maintainability, and consistency across your project.

What triggers this rule:
Any direct instantiation of a class using ClassName() or new ClassName(), except for: Classes that extend Module
Classes that have a factory constructor