### PR TITLE
Add sealed class over dynamic for sync results in the prod code

### DIFF
--- a/example/example_sealed_over_dynamic_rule.dart
+++ b/example/example_sealed_over_dynamic_rule.dart
@@ -1,0 +1,21 @@
+// ❌ Bad: Using dynamic for sync result
+void bad() async {
+  dynamic syncResult =
+      await powersync.execute('query'); // LINT: Use a sealed class instead
+}
+
+// ✅ Good: Using a sealed class for sync result
+sealed class SyncResult {}
+
+void good() async {
+  SyncResult result = await powersync.execute('query');
+}
+
+// Mock powersync object for demonstration
+final powersync = _PowerSync();
+
+class _PowerSync {
+  Future<dynamic> execute(String query) async => SyncResultImpl();
+}
+
+class SyncResultImpl extends SyncResult {}

--- a/lib/ripplearc_flutter_lint.dart
+++ b/lib/ripplearc_flutter_lint.dart
@@ -1,6 +1,7 @@
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:ripplearc_flutter_lint/rules/no_direct_instantiation.dart';
 import 'package:ripplearc_flutter_lint/rules/document_fake_parameters.dart';
+import 'package:ripplearc_flutter_lint/rules/sealed_over_dynamic.dart';
 import 'package:ripplearc_flutter_lint/rules/todo_with_story_links.dart';
 import 'package:ripplearc_flutter_lint/rules/no_internal_method_docs.dart';
 import 'rules/prefer_fake_over_mock_rule.dart';
@@ -21,5 +22,6 @@ class _RipplearcFlutterLint extends PluginBase {
     const TodoWithStoryLinks(),
     const NoInternalMethodDocs(),
     const DocumentInterface(),
+    const SealedOverDynamic(),
   ];
 }

--- a/lib/rules/sealed_over_dynamic.dart
+++ b/lib/rules/sealed_over_dynamic.dart
@@ -1,0 +1,76 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart' hide LintCode;
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// Enforces the use of sealed classes over dynamic for sync results.
+///
+/// This rule flags any use of `dynamic` for sync results and suggests using a sealed class instead.
+///
+/// Example:
+/// ```dart
+/// // ❌ Not allowed:
+/// dynamic syncResult = await powersync.execute(query);
+///
+/// // ✅ Allowed:
+/// sealed class SyncResult {}
+/// SyncResult result = await powersync.execute(query);
+/// ```
+class SealedOverDynamic extends DartLintRule {
+  const SealedOverDynamic() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'sealed_over_dynamic',
+    problemMessage:
+        'Do not use dynamic for sync results. Use a sealed class instead.',
+    correctionMessage: 'Declare a sealed class and use it for sync results.',
+    errorSeverity: ErrorSeverity.ERROR,
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addCompilationUnit((node) {
+      _checkForDynamicSyncResult(node, reporter);
+    });
+  }
+
+  void _checkForDynamicSyncResult(
+    CompilationUnit node,
+    ErrorReporter reporter,
+  ) {
+    node.visitChildren(_SealedOverDynamicVisitor(reporter));
+  }
+}
+
+class _SealedOverDynamicVisitor extends RecursiveAstVisitor<void> {
+  final ErrorReporter reporter;
+  _SealedOverDynamicVisitor(this.reporter);
+
+  @override
+  void visitVariableDeclaration(VariableDeclaration node) {
+    final parent = node.parent;
+    if (parent is VariableDeclarationList) {
+      final type = parent.type;
+      if (type != null && type.toString() == 'dynamic') {
+        reporter.atNode(node, SealedOverDynamic._code);
+      }
+    }
+    super.visitVariableDeclaration(node);
+  }
+
+  @override
+  void visitAssignmentExpression(AssignmentExpression node) {
+    final left = node.leftHandSide;
+    if (left is SimpleIdentifier &&
+        left.staticType != null &&
+        left.staticType.toString() == 'dynamic') {
+      reporter.atNode(node, SealedOverDynamic._code);
+    }
+    super.visitAssignmentExpression(node);
+  }
+}

--- a/test/rules/sealed_over_dynamic_test.dart
+++ b/test/rules/sealed_over_dynamic_test.dart
@@ -1,0 +1,89 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:test/test.dart';
+import 'package:ripplearc_flutter_lint/rules/sealed_over_dynamic.dart';
+import '../utils/test_error_reporter.dart';
+
+void main() {
+  group('SealedOverDynamic', () {
+    late SealedOverDynamic rule;
+    late TestErrorReporter reporter;
+    late CompilationUnit unit;
+
+    setUp(() {
+      rule = const SealedOverDynamic();
+      reporter = TestErrorReporter();
+    });
+
+    Future<void> analyzeCode(String sourceCode) async {
+      final parseResult = parseString(content: sourceCode);
+      unit = parseResult.unit;
+      rule.run(_TestResolver(unit), reporter, _TestContext(unit));
+    }
+
+    test('flags dynamic sync result', () async {
+      const source = '''
+      void main() async {
+        dynamic syncResult = await powersync.execute('query');
+      }
+      final powersync = _PowerSync();
+      class _PowerSync {
+        Future<dynamic> execute(String query) async => null;
+      }
+      ''';
+      await analyzeCode(source);
+      expect(reporter.errors, isNotEmpty);
+      expect(
+        reporter.errors.first.errorCode.name,
+        equals('sealed_over_dynamic'),
+      );
+    });
+
+    test('allows sealed class sync result', () async {
+      const source = '''
+      sealed class SyncResult {}
+      void main() async {
+        SyncResult result = await powersync.execute('query');
+      }
+      final powersync = _PowerSync();
+      class _PowerSync {
+        Future<SyncResult> execute(String query) async => SyncResultImpl();
+      }
+      class SyncResultImpl extends SyncResult {}
+      ''';
+      await analyzeCode(source);
+      expect(reporter.errors, isEmpty);
+    });
+  });
+}
+
+class _TestResolver implements CustomLintResolver {
+  _TestResolver(this.unit);
+  final CompilationUnit unit;
+  @override
+  String get path => 'test.dart';
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TestContext implements CustomLintContext {
+  _TestContext(this.unit);
+  final CompilationUnit unit;
+  @override
+  LintRuleNodeRegistry get registry => _TestRegistry(unit);
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TestRegistry implements LintRuleNodeRegistry {
+  _TestRegistry(this.unit);
+  final CompilationUnit unit;
+  @override
+  void addCompilationUnit(Function(CompilationUnit) callback) {
+    callback(unit);
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}


### PR DESCRIPTION
# Summary

Add sealed class over dynamic for sync results in the prod code

## Why This Rule?

Using `dynamic` for sync results reduces type safety and makes conflict resolution and debugging harder. This rule enforces the use of a sealed class (such as `SyncResult`) instead of `dynamic` for offline sync results, improving code clarity and maintainability.

## Changes

- Added `SealedOverDynamic` rule to detect and error on `dynamic` usage for sync results.
- The rule encourages using a sealed class for type safety.
- Provided an example file demonstrating both violations and correct usage.
- Added tests to ensure the rule flags only `dynamic` and allows sealed class usage.

## Technical Details

The rule scans for variable declarations and assignments using `dynamic` for sync results and reports an error. Using a sealed class for sync results is allowed. The rule is enforced as an error to ensure type safety in critical code paths.

## Benefits

- Improves type safety and reliability in sync logic.
- Encourages the use of sealed classes for clear, maintainable code.
- Promotes best practices for robust offline sync and conflict resolution.

## Example Command and Output

To verify the rule, run:

```sh
dart run custom_lint | grep example/example_sealed_over_dynamic_rule

example/example_sealed_over_dynamic_rule.dart:3:11 • Do not use dynamic for sync results. Use a sealed class instead. • sealed_over_dynamic • ERROR
example/example_sealed_over_dynamic_rule.dart:15:19 • Direct instantiation is not allowed. Use dependency injection instead. • no_direct_instantiation • ERROR
example/example_sealed_over_dynamic_rule.dart:18:50 • Direct instantiation is not allowed. Use dependency injection instead. • no_direct_instantiation • ERROR
```