### PR TITLE
Add avoid test timeouts in the prod code

### DIFF
--- a/example/example_avoid_test_timeouts_rule.dart
+++ b/example/example_avoid_test_timeouts_rule.dart
@@ -1,0 +1,34 @@
+import 'dart:async';
+import 'package:test/test.dart';
+
+void main() {
+  // ❌ Bad: Using .timeout() and Future.delayed() in tests
+  test('bad example', () async {
+    await getFuture().timeout(getDuration()); // LINT: Can cause flaky tests
+    await getDelayedFuture(); // LINT: Can cause flaky tests
+  });
+
+  // ✅ Good: Using expectLater and proper async/await patterns
+  test('good example', () async {
+    await expectLater(
+        getStream(), emits('expected')); // Good: Proper stream testing
+    await pumpAndSettle(); // Good: Proper widget testing
+  });
+}
+
+// Mock functions that return existing objects (would be provided by DI in real code)
+Future<String> getFuture() async => 'result';
+Stream<String> getStream() => getExistingStream();
+Duration getDuration() => getExistingDuration();
+Future<void> getDelayedFuture() async => await getExistingDelayedFuture();
+
+// These would be provided by dependency injection in real code
+Stream<String> getExistingStream() => const Stream.empty();
+Duration getExistingDuration() => Duration.zero;
+Future<void> getExistingDelayedFuture() async {}
+
+Future<void> pumpAndSettle() async {}
+
+Future<void> expectLater(Stream<String> stream, dynamic matcher) async {}
+
+dynamic emits(dynamic value) => value;

--- a/lib/ripplearc_flutter_lint.dart
+++ b/lib/ripplearc_flutter_lint.dart
@@ -1,4 +1,5 @@
 import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:ripplearc_flutter_lint/rules/avoid_test_timeouts.dart';
 import 'package:ripplearc_flutter_lint/rules/no_direct_instantiation.dart';
 import 'package:ripplearc_flutter_lint/rules/document_fake_parameters.dart';
 import 'package:ripplearc_flutter_lint/rules/todo_with_story_links.dart';
@@ -21,5 +22,6 @@ class _RipplearcFlutterLint extends PluginBase {
     const TodoWithStoryLinks(),
     const NoInternalMethodDocs(),
     const DocumentInterface(),
+    const AvoidTestTimeouts(),
   ];
 }

--- a/lib/rules/avoid_test_timeouts.dart
+++ b/lib/rules/avoid_test_timeouts.dart
@@ -1,0 +1,97 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart' hide LintCode;
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// A lint rule that forbids using .timeout() and Future.delayed() in test files.
+///
+/// This rule flags timeout and delay patterns in test blocks to prevent flaky tests
+/// and encourage the use of proper async/await patterns and expectLater.
+///
+/// Example of code that triggers this rule:
+/// ```dart
+/// test('example', () async {
+///   await userCompleter.future.timeout(Duration(seconds: 1));  // LINT
+///   await Future.delayed(Duration(milliseconds: 10));  // LINT
+/// });
+/// ```
+///
+/// Example of code that doesn't trigger this rule:
+/// ```dart
+/// test('example', () async {
+///   await expectLater(userStream, emits(expectedUser));
+///   await tester.pumpAndSettle();
+/// });
+/// ```
+class AvoidTestTimeouts extends DartLintRule {
+  const AvoidTestTimeouts() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'avoid_test_timeouts',
+    problemMessage:
+        'Using .timeout() or Future.delayed() in tests can cause flaky tests. Use expectLater or proper async/await patterns instead.',
+    correctionMessage:
+        'Replace with expectLater for streams or proper async/await patterns.',
+    errorSeverity: ErrorSeverity.ERROR,
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addCompilationUnit((node) {
+      if (!_isTestFile(resolver.path)) return;
+      _checkForTestTimeouts(node, reporter);
+    });
+  }
+
+  bool _isTestFile(String path) {
+    return path.contains('_test.dart') ||
+        path.contains('/test/') ||
+        path.contains('/example/') ||
+        path.contains('example_');
+  }
+
+  void _checkForTestTimeouts(CompilationUnit node, ErrorReporter reporter) {
+    final visitor = _TestTimeoutVisitor(reporter);
+    node.accept(visitor);
+  }
+}
+
+class _TestTimeoutVisitor extends RecursiveAstVisitor<void> {
+  _TestTimeoutVisitor(this._reporter);
+
+  final ErrorReporter _reporter;
+  bool _isInTestBlock = false;
+  bool _isInSetupOrTeardown = false;
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    final name = node.methodName.name;
+    if (name == 'test' || name == 'group') {
+      _isInTestBlock = true;
+      super.visitMethodInvocation(node);
+      _isInTestBlock = false;
+    } else if (name == 'setUp' || name == 'tearDown') {
+      _isInSetupOrTeardown = true;
+      super.visitMethodInvocation(node);
+      _isInSetupOrTeardown = false;
+    } else {
+      // Check for .timeout() method calls
+      if (_isInTestBlock && !_isInSetupOrTeardown && name == 'timeout') {
+        _reporter.atNode(node, AvoidTestTimeouts._code);
+      }
+      // Check for Future.delayed() method calls
+      if (_isInTestBlock && !_isInSetupOrTeardown && name == 'delayed') {
+        final target = node.target;
+        if (target is Identifier && target.name == 'Future') {
+          _reporter.atNode(node, AvoidTestTimeouts._code);
+        }
+      }
+      super.visitMethodInvocation(node);
+    }
+  }
+}

--- a/test/rules/avoid_test_timeouts_test.dart
+++ b/test/rules/avoid_test_timeouts_test.dart
@@ -1,0 +1,125 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:test/test.dart';
+import 'package:ripplearc_flutter_lint/rules/avoid_test_timeouts.dart';
+import '../utils/test_error_reporter.dart';
+
+void main() {
+  group('AvoidTestTimeouts', () {
+    late AvoidTestTimeouts rule;
+    late TestErrorReporter reporter;
+    late CompilationUnit unit;
+
+    setUp(() {
+      rule = const AvoidTestTimeouts();
+      reporter = TestErrorReporter();
+    });
+
+    Future<void> analyzeCode(String sourceCode) async {
+      final parseResult = parseString(content: sourceCode);
+      unit = parseResult.unit;
+      rule.run(_TestResolver(unit), reporter, _TestContext(unit));
+    }
+
+    test('flags .timeout() in test block', () async {
+      const source = '''
+import 'dart:async';
+final userCompleter = Completer<User>();
+class User {}
+void main() {
+  test('example', () async {
+    await userCompleter.future.timeout(Duration(seconds: 1));
+  });
+}
+''';
+      await analyzeCode(source);
+      expect(reporter.errors, isNotEmpty);
+      expect(
+        reporter.errors.first.errorCode.name,
+        equals('avoid_test_timeouts'),
+      );
+    });
+
+    test('flags Future.delayed() in test block', () async {
+      const source = '''
+import 'dart:async';
+void main() {
+  test('example', () async {
+    await Future.delayed(Duration(milliseconds: 10));
+  });
+}
+''';
+      await analyzeCode(source);
+      expect(reporter.errors, isNotEmpty);
+      expect(
+        reporter.errors.first.errorCode.name,
+        equals('avoid_test_timeouts'),
+      );
+    });
+
+    test('allows expectLater in test block', () async {
+      const source = '''
+import 'dart:async';
+final userStream = StreamController<User>();
+final expectedUser = User();
+class User {}
+Future<void> expectLater(Stream<User> stream, dynamic matcher) async {}
+dynamic emits(dynamic value) => value;
+void main() {
+  test('example', () async {
+    await expectLater(userStream, emits(expectedUser));
+  });
+}
+''';
+      await analyzeCode(source);
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('allows pumpAndSettle in test block', () async {
+      const source = '''
+final tester = _Tester();
+class _Tester {
+  Future<void> pumpAndSettle() async {}
+}
+void main() {
+  test('example', () async {
+    await tester.pumpAndSettle();
+  });
+}
+''';
+      await analyzeCode(source);
+      expect(reporter.errors, isEmpty);
+    });
+  });
+}
+
+class _TestResolver implements CustomLintResolver {
+  _TestResolver(this.unit);
+  final CompilationUnit unit;
+  @override
+  String get path => 'foo_test.dart';
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TestContext implements CustomLintContext {
+  _TestContext(this.unit);
+  final CompilationUnit unit;
+  @override
+  LintRuleNodeRegistry get registry => _TestRegistry(unit);
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TestRegistry implements LintRuleNodeRegistry {
+  _TestRegistry(this.unit);
+  final CompilationUnit unit;
+  @override
+  void addCompilationUnit(Function(CompilationUnit) callback) {
+    callback(unit);
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}


### PR DESCRIPTION
# Summary

Add avoid test timeouts in the prod code

## Why This Rule?

Using `.timeout()` and `Future.delayed()` in tests can cause flaky tests and unreliable test results. This rule enforces the use of proper async/await patterns and `expectLater` instead of timeouts and delays, improving test reliability and maintainability.

## Changes

- Added `AvoidTestTimeouts` rule to detect and error on `.timeout()` and `Future.delayed()` usage in test files.
- The rule encourages using `expectLater` for stream testing and proper async/await patterns.
- Provided an example file demonstrating both violations and correct usage.
- Added tests to ensure the rule flags only timeout/delay patterns and allows proper testing patterns.

## Technical Details

The rule scans for `.timeout()` method calls and `Future.delayed()` usage in test blocks and reports an error. Using `expectLater` for streams and `pumpAndSettle()` for widget testing is allowed. The rule is enforced as an error to ensure reliable test execution.

## Benefits

- Prevents flaky tests caused by arbitrary timeouts and delays.
- Encourages the use of proper testing patterns like `expectLater` and `pumpAndSettle`.
- Promotes best practices for robust and reliable test execution.

## Example Command and Output

To verify the rule, run:

```sh
dart run custom_lint | grep example/example_avoid_test_timeouts_rule

example/example_avoid_test_timeouts_rule.dart:7:11 • Using .timeout() or Future.delayed() in tests can cause flaky tests. Use expectLater or proper async/await patterns instead. • avoid_test_timeouts • ERROR
example/example_avoid_test_timeouts_rule.dart:26:39 • Direct instantiation is not allowed. Use dependency injection instead. • no_direct_instantiation • ERROR
```