### PR TITLE
Add private subject rule in the prod code

### DIFF
--- a/example/example_private_subject_rule.dart
+++ b/example/example_private_subject_rule.dart
@@ -1,0 +1,61 @@
+import 'package:rxdart/rxdart.dart';
+
+enum AuthStatus { authenticated, unauthenticated }
+
+class User {
+  final String name;
+  final String email;
+  User({required this.name, required this.email});
+}
+
+class AuthService {
+  // Bad: Public Subject variables
+  final authStateController = BehaviorSubject<AuthStatus>(); // LINT
+  final userController = ReplaySubject<User>(); // LINT
+  final loginController = PublishSubject<void>(); // LINT
+
+  // Good: Private Subject variables
+  final _authStateController = BehaviorSubject<AuthStatus>(); // Good
+  final _userController = ReplaySubject<User?>(); // Good
+  final _loginController = PublishSubject<void>(); // Good
+
+  // Good: Non-Subject variables are allowed to be public
+  final user = User(name: 'John', email: 'john@example.com');
+  final status = AuthStatus.authenticated;
+
+  // Good: Private non-Subject variables
+  final _internalData = 'private data';
+
+  void login() {
+    _authStateController.add(AuthStatus.authenticated);
+    _userController.add(user);
+    _loginController.add(null);
+  }
+
+  void logout() {
+    _authStateController.add(AuthStatus.unauthenticated);
+    _userController.add(null);
+  }
+
+  // Good: Public getters for streams
+  Stream<AuthStatus> get authState => _authStateController.stream;
+  Stream<User?> get userStream => _userController.stream;
+  Stream<void> get loginEvents => _loginController.stream;
+}
+
+void main() {
+  final authService = AuthService();
+
+  // Good: Using public getters instead of direct access
+  authService.authState.listen((status) {
+    print('Auth status: $status');
+  });
+
+  authService.userStream.listen((user) {
+    if (user != null) {
+      print('User: ${user.name}');
+    }
+  });
+
+  authService.login();
+}

--- a/lib/ripplearc_flutter_lint.dart
+++ b/lib/ripplearc_flutter_lint.dart
@@ -5,6 +5,7 @@ import 'rules/prefer_fake_over_mock_rule.dart';
 import 'rules/forbid_forced_unwrapping.dart';
 import 'rules/no_optional_operators_in_tests.dart';
 import 'rules/document_interface.dart';
+import 'rules/private_subject.dart';
 
 PluginBase createPlugin() => _RipplearcFlutterLint();
 
@@ -17,5 +18,6 @@ class _RipplearcFlutterLint extends PluginBase {
     const TodoWithStoryLinks(),
     const NoInternalMethodDocs(),
     const DocumentInterface(),
+    const PrivateSubject(),
   ];
 }

--- a/lib/rules/private_subject.dart
+++ b/lib/rules/private_subject.dart
@@ -1,0 +1,79 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart' hide LintCode;
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// A lint rule that enforces Subject variables to be private.
+///
+/// This rule prevents external manipulation of Subject streams by ensuring
+/// that all Subject variables (BehaviorSubject, ReplaySubject, PublishSubject)
+/// are declared as private with an underscore prefix.
+///
+/// Example of code that triggers this rule:
+/// ```dart
+/// final authStateController = BehaviorSubject<AuthStatus>();  // LINT
+/// final userController = ReplaySubject<User>();              // LINT
+/// ```
+///
+/// Example of code that doesn't trigger this rule:
+/// ```dart
+/// final _authStateController = BehaviorSubject<AuthStatus>();  // Good
+/// final _userController = ReplaySubject<User>();              // Good
+/// ```
+class PrivateSubject extends DartLintRule {
+  const PrivateSubject() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'private_subject',
+    problemMessage:
+        'Subject variables must be private to prevent external manipulation.',
+    correctionMessage: 'Add underscore prefix to make the variable private.',
+    errorSeverity: ErrorSeverity.ERROR,
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addCompilationUnit((node) {
+      _checkForPublicSubjects(node, reporter);
+    });
+  }
+
+  void _checkForPublicSubjects(CompilationUnit node, ErrorReporter reporter) {
+    final visitor = _PrivateSubjectVisitor(reporter);
+    node.accept(visitor);
+  }
+}
+
+class _PrivateSubjectVisitor extends RecursiveAstVisitor<void> {
+  _PrivateSubjectVisitor(this.reporter);
+
+  final ErrorReporter reporter;
+
+  @override
+  void visitVariableDeclaration(VariableDeclaration node) {
+    final initializer = node.initializer;
+    if (initializer != null) {
+      final source = initializer.toSource();
+      if (_isSubjectType(source)) {
+        final name = node.name.lexeme;
+        if (!name.startsWith('_')) {
+          reporter.atNode(node, PrivateSubject._code);
+        }
+      }
+    }
+    super.visitVariableDeclaration(node);
+  }
+
+  bool _isSubjectType(String typeName) {
+    final lower = typeName.toLowerCase();
+    return lower.contains('behaviorsubject') ||
+        lower.contains('replaysubject') ||
+        lower.contains('publishsubject') ||
+        lower.contains('subject');
+  }
+}

--- a/test/rules/private_subject_test.dart
+++ b/test/rules/private_subject_test.dart
@@ -1,0 +1,200 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/source/line_info.dart';
+import 'package:analyzer/source/source.dart';
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:ripplearc_flutter_lint/rules/private_subject.dart';
+import 'package:test/test.dart';
+import '../utils/test_error_reporter.dart';
+
+void main() {
+  group('PrivateSubject', () {
+    late PrivateSubject rule;
+    late TestErrorReporter reporter;
+    late CompilationUnit unit;
+
+    setUp(() {
+      rule = const PrivateSubject();
+      reporter = TestErrorReporter();
+    });
+
+    Future<void> analyzeCode(String sourceCode, {required String path}) async {
+      final parseResult = parseString(content: sourceCode);
+      unit = parseResult.unit;
+      rule.run(
+        TestCustomLintResolver(unit, path),
+        reporter,
+        TestCustomLintContext(unit),
+      );
+    }
+
+    test('should flag public BehaviorSubject variables', () async {
+      const source = '''
+      import 'package:rxdart/rxdart.dart';
+      
+      class TestClass {
+        final authController = BehaviorSubject<String>();
+        final _privateController = BehaviorSubject<String>();
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/example.dart');
+      expect(reporter.errors, hasLength(1));
+      expect(reporter.errors.first.errorCode.name, equals('private_subject'));
+    });
+
+    test('should flag public ReplaySubject variables', () async {
+      const source = '''
+      import 'package:rxdart/rxdart.dart';
+      
+      class TestClass {
+        final userController = ReplaySubject<int>();
+        final _privateController = ReplaySubject<int>();
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/example.dart');
+      expect(reporter.errors, hasLength(1));
+      expect(reporter.errors.first.errorCode.name, equals('private_subject'));
+    });
+
+    test('should flag public PublishSubject variables', () async {
+      const source = '''
+      import 'package:rxdart/rxdart.dart';
+      
+      class TestClass {
+        final eventController = PublishSubject<void>();
+        final _privateController = PublishSubject<void>();
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/example.dart');
+      expect(reporter.errors, hasLength(1));
+      expect(reporter.errors.first.errorCode.name, equals('private_subject'));
+    });
+
+    test('should flag public Subject variables', () async {
+      const source = '''
+      import 'package:rxdart/rxdart.dart';
+      
+      class TestClass {
+        final genericController = Subject<String>();
+        final _privateController = Subject<String>();
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/example.dart');
+      expect(reporter.errors, hasLength(1));
+      expect(reporter.errors.first.errorCode.name, equals('private_subject'));
+    });
+
+    test('should not flag private Subject variables', () async {
+      const source = '''
+      import 'package:rxdart/rxdart.dart';
+      
+      class TestClass {
+        final _authController = BehaviorSubject<String>();
+        final _userController = ReplaySubject<int>();
+        final _eventController = PublishSubject<void>();
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/example.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should not flag non-Subject variables', () async {
+      const source = '''
+      class TestClass {
+        final publicVariable = 'test';
+        final _privateVariable = 'test';
+        final controller = StreamController<String>();
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/example.dart');
+      expect(reporter.errors, isEmpty);
+    });
+
+    test('should flag multiple public Subject variables', () async {
+      const source = '''
+      import 'package:rxdart/rxdart.dart';
+      
+      class TestClass {
+        final authController = BehaviorSubject<String>();
+        final userController = ReplaySubject<int>();
+        final eventController = PublishSubject<void>();
+        final _privateController = BehaviorSubject<String>();
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/example.dart');
+      expect(reporter.errors, hasLength(3));
+      expect(
+        reporter.errors.every(
+          (error) => error.errorCode.name == 'private_subject',
+        ),
+        isTrue,
+      );
+    });
+
+    test('debug: should detect any variable declaration', () async {
+      const source = '''
+      class TestClass {
+        final testVar = 'test';
+      }
+      ''';
+      await analyzeCode(source, path: 'lib/example.dart');
+      // This test just ensures the rule runs without crashing
+      expect(reporter.errors, isEmpty);
+    });
+  });
+}
+
+class TestCustomLintResolver implements CustomLintResolver {
+  TestCustomLintResolver(this.unit, this.path);
+  final CompilationUnit unit;
+  @override
+  final String path;
+
+  @override
+  Future<ResolvedUnitResult> getResolvedUnitResult() async {
+    throw UnimplementedError();
+  }
+
+  @override
+  LineInfo get lineInfo => throw UnimplementedError();
+
+  @override
+  Source get source => throw UnimplementedError();
+}
+
+class _MockLintRuleNodeRegistry implements LintRuleNodeRegistry {
+  final CompilationUnit unit;
+
+  _MockLintRuleNodeRegistry(this.unit);
+
+  @override
+  void addCompilationUnit(Function(CompilationUnit) callback) {
+    callback(unit);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => throw UnimplementedError();
+}
+
+class TestCustomLintContext implements CustomLintContext {
+  TestCustomLintContext(this.unit);
+  final CompilationUnit unit;
+
+  void addCompilationUnit(Function(CompilationUnit) callback) {
+    callback(unit);
+  }
+
+  @override
+  void addPostRunCallback(Function() callback) {}
+
+  @override
+  Pubspec get pubspec => throw UnimplementedError();
+
+  @override
+  Map<String, dynamic> get sharedState => {};
+
+  @override
+  LintRuleNodeRegistry get registry => _MockLintRuleNodeRegistry(unit);
+}


### PR DESCRIPTION
# Summary

Add private subject rule in the prod code

## Why This Rule?

Prevents external manipulation of Subject streams by ensuring all Subject variables (BehaviorSubject, ReplaySubject, PublishSubject) are declared as private. This enforces encapsulation and prevents direct access to stream controllers from outside the class.

## Changes

- Added `PrivateSubject` rule to detect and error on public Subject variable declarations.
- The rule flags variables that don't start with underscore when initialized with Subject types.
- Provided an example file demonstrating both violations and correct usage patterns.
- Added comprehensive tests covering all Subject types and edge cases.

## Technical Details

The rule checks variable declarations for Subject initializers using case-insensitive substring matching on the initializer's source. It flags public variables (no underscore prefix) that are initialized with BehaviorSubject, ReplaySubject, PublishSubject, or Subject constructors.

## Benefits

- Enforces proper encapsulation of stream controllers.
- Prevents external code from directly manipulating Subject streams.
- Encourages use of public getters for stream access instead of direct controller access.
- Promotes better architectural patterns for reactive programming.

## Example Command and Output

To verify the rule, run:

```sh
dart run custom_lint | grep example/example_private_subject_rule

example/example_private_subject_rule.dart:13:9 • Subject variables must be private to prevent external manipulation. • private_subject • ERROR
example/example_private_subject_rule.dart:14:9 • Subject variables must be private to prevent external manipulation. • private_subject • ERROR
example/example_private_subject_rule.dart:15:9 • Subject variables must be private to prevent external manipulation. • private_subject • ERROR
```