### PR TITLE
Feat/ca 477 develop automated pr agent for linter rules

### DIFF
--- a/docs/wiki-create-custom-linter-rule-with-agent.md
+++ b/docs/wiki-create-custom-linter-rule-with-agent.md
@@ -1,0 +1,174 @@
+# Wiki: Create a Custom Linter Rule Using the Cursor Agent
+
+This guide explains how to add a new custom linter rule to this project by giving the Cursor agent a rule spec and having it follow the instructions in `scripts/create_linter_rule_from_spec.sh`. The agent will generate the analyzer, rule class, registration, and optional tests; then you (or the agent) run the script to create the branch and open a PR.
+
+---
+
+## Prerequisites
+
+- **Cursor** with agent/composer available.
+- This repo open in Cursor (`ripplearc-flutter-lint`).
+- A **rule spec** in Markdown (or text) describing what the rule should do (see below).
+- For opening the PR from the script: **Git** and optionally **GitHub CLI** (`gh`) installed and authenticated.
+
+---
+
+## 1. Rule spec format
+
+The agent expects a **structured spec** so it can generate correct code. Use this format (`.md` or `.txt`).
+
+### Required
+
+- **Rule name**: First heading, snake_case.  
+  Example: `# forbid_foo`
+- **Description**: One or two sentences after the heading (what the rule forbids or enforces).
+- **Bad**: A `## Bad` section with a Dart code block showing code that **should** be reported.
+- **Good**: A `## Good` section with a Dart code block showing code that is **allowed**.
+
+### Optional
+
+- **Scope**: Line like `**Scope**: include_tests` or `**Scope**: test_only`.  
+  - `test_only` → rule runs only in test files.  
+  - `include_tests` → rule runs in both lib and test.  
+  - Omit → rule runs only in production (lib) code.
+- **Exceptions**: When to skip the rule (e.g. “Skip in files ending with `_impl.dart`”).
+
+### Example spec
+
+Save this as `rule_specs/forbid_foo.md` (or paste it in chat):
+
+```markdown
+# forbid_foo
+
+Short description: do not use Foo.bar() in production; use Baz.bar() instead for testability.
+
+**Scope**: include_tests
+**Exceptions**: Skip in `foo_impl.dart`
+
+## Bad
+```dart
+void doSomething() {
+  Foo.bar();  // should be reported
+}
+```
+
+## Good
+```dart
+void doSomething(Baz baz) {
+  baz.bar();  // OK
+}
+```
+```
+
+You can put spec files under a `rule_specs/` folder or any path; just tell the agent where it is or paste the content.
+
+---
+
+## 2. How to use the agent
+
+### Step 1: Tell the agent what to do
+
+In Cursor, open the agent (Composer or Chat) and say something like:
+
+- *“Follow the instructions in `scripts/create_linter_rule_from_spec.sh` and create a new linter rule from this spec.”*
+- Then either:
+  - **Attach or reference the spec file**, e.g. `rule_specs/my_rule.md`, or  
+  - **Paste the spec** (rule name, description, Bad/Good, optional Scope and Exceptions) in the message.
+
+Example:
+
+> Follow the instructions in **scripts/create_linter_rule_from_spec.sh** and create a new linter rule. The rule spec is in **rule_specs/forbid_foo.md** (or see below).
+>
+> [Optional: paste spec content if not using a file]
+
+### Step 2: What the agent will do
+
+The agent will read the **AGENT INSTRUCTIONS** inside `scripts/create_linter_rule_from_spec.sh` and:
+
+1. Parse the spec (rule name, description, scope, exceptions, Bad/Good examples).
+2. Create **lib/core/analyzers/<rule_name>_analyzer.dart** (AST visitor, `createIssue`, etc.).
+3. Create **lib/custom_lint_rules/<rule_name>.dart** (extends `BaseLintRule`, wires the analyzer).
+4. Update **lib/ripplearc_linter.dart** (import and add the rule to `getLintRules`).
+5. Optionally add **test/custom_lint_rules/<rule_name>_test.dart** and/or **example/** and **docs/**.
+
+It will use existing rules (e.g. `forbid_datetime_now`) as references.
+
+### Step 3: Create the branch and PR
+
+After the agent has created or updated the files:
+
+1. Open a terminal in the repo root.
+2. Run the script with the **rule name** (snake_case) and optionally the base branch:
+
+   ```bash
+   ./scripts/create_linter_rule_from_spec.sh <rule_name> [base_branch]
+   ```
+
+   Examples:
+
+   ```bash
+   ./scripts/create_linter_rule_from_spec.sh forbid_foo
+   ./scripts/create_linter_rule_from_spec.sh my_new_rule main
+   ```
+
+3. The script will:
+   - Create branch `rule/<rule_name>` from your current branch (keeping all new changes).
+   - Stage the new/updated rule files.
+   - Ask for confirmation, then commit with message `Add <rule_name> linter rule`.
+   - Push the branch.
+   - If `gh` is installed, create a PR against `base_branch` (default: `main`).
+
+If you prefer, you can ask the agent to run this script for you (e.g. “run create_linter_rule_from_spec.sh with rule name forbid_foo”) after it has generated the files.
+
+---
+
+## 3. Quick reference
+
+| Step | Who | Action |
+|------|-----|--------|
+| 1 | You | Write or paste the rule spec (name, description, Bad, Good, optional Scope/Exceptions). |
+| 2 | You | In Cursor, ask the agent to follow `scripts/create_linter_rule_from_spec.sh` and use that spec. |
+| 3 | Agent | Creates analyzer, rule class, registration, and optionally tests/example/docs. |
+| 4 | You or Agent | Run `./scripts/create_linter_rule_from_spec.sh <rule_name> [base_branch]` to create branch, commit, push, and open PR. |
+
+---
+
+## 4. Where things live
+
+- **Rule spec**: e.g. `rule_specs/<rule_name>.md` (or any path you give the agent).
+- **Instructions for the agent**: Inside `scripts/create_linter_rule_from_spec.sh` (AGENT INSTRUCTIONS block).
+- **Generated files**:
+  - `lib/core/analyzers/<rule_name>_analyzer.dart`
+  - `lib/custom_lint_rules/<rule_name>.dart`
+  - `lib/ripplearc_linter.dart` (updated)
+  - Optionally: `test/...`, `example/...`, `docs/<rule_name>.md`
+- **Full plan**: `docs/agent-rule-from-spec-plan.md`.
+
+---
+
+## 5. Troubleshooting
+
+- **Agent didn’t register the rule**  
+  Remind it to add the import and the rule instance in `lib/ripplearc_linter.dart` (step 4 in the script instructions).
+
+- **Script says “No changes to commit”**  
+  Ensure the new Dart files and changes to `ripplearc_linter.dart` are saved and that you’re in the repo root when running the script.
+
+- **PR not created**  
+  Install and log in to GitHub CLI: `gh auth login`. Then run the script again, or create the PR manually from the link the script prints.
+
+- **Rule name with dashes or spaces**  
+  The script normalizes the first argument to snake_case (e.g. `forbid-foo` → `forbid_foo`). Use the same name the agent used in file paths.
+
+- **Tests or analyzer don’t match spec**  
+  Refine the spec (clearer Bad/Good examples) and ask the agent to update the analyzer and tests accordingly.
+
+---
+
+## 6. Summary
+
+1. Write a rule spec (Markdown with rule name, description, Bad, Good, optional Scope/Exceptions).
+2. In Cursor, ask the agent to follow **scripts/create_linter_rule_from_spec.sh** and use that spec.
+3. After the agent creates the files, run **./scripts/create_linter_rule_from_spec.sh \<rule_name>** to create the branch and PR.
+
+The script is the single place for both **what the agent should do** (instructions inside it) and **how to create the PR** (running the script after the agent is done).

--- a/scripts/create_linter_rule_from_spec.sh
+++ b/scripts/create_linter_rule_from_spec.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+#
+# create_linter_rule_from_spec.sh
+#
+# Purpose:
+#   1. Provides instructions for the Cursor agent to create a new linter rule from a spec file.
+#   2. After the agent has created the files, this script creates the branch, commits, pushes,
+#      and opens a PR.
+#
+# Usage (by user/agent):
+#   Step A: In Cursor, ask the agent to follow the AGENT INSTRUCTIONS below and use your rule spec.
+#   Step B: After the agent has created/updated all files, run:
+#     ./scripts/create_linter_rule_from_spec.sh <rule_name> [base_branch]
+#   Example:
+#     ./scripts/create_linter_rule_from_spec.sh forbid_foo
+#     ./scripts/create_linter_rule_from_spec.sh my_new_rule main
+#
+# Arguments:
+#   rule_name   (required) Snake_case name of the rule, e.g. forbid_datetime_now
+#   base_branch (optional) Branch to create PR against. Default: main
+#
+# Requirements:
+#   - Git repository clean or with only the new rule files changed.
+#   - For PR creation: `gh` (GitHub CLI) installed and authenticated.
+#
+# =============================================================================
+# AGENT INSTRUCTIONS (read and follow when the user asks you to create a rule)
+# =============================================================================
+#
+# When the user asks you to create a custom linter rule and mentions this script
+# (or points you to scripts/create_linter_rule_from_spec.sh), do the following.
+#
+# --- INPUT ---
+# The user will provide:
+#   - A rule spec: either a path to a .md or .txt file (e.g. rule_specs/my_rule.md),
+#     or the spec content pasted in the chat.
+#
+# Spec format (structured Markdown):
+#   - First heading: rule name in snake_case, e.g. "# forbid_foo"
+#   - Short description (1–2 sentences) after the heading
+#   - Optional: **Scope**: one of "test_only" | "include_tests" | (omit = production only)
+#   - Optional: **Exceptions**: when to skip (e.g. "Skip in path ending with x.dart")
+#   - ## Bad — code block(s) showing code that should trigger the rule
+#   - ## Good — code block(s) showing correct code
+#
+# --- STEPS TO PERFORM (in order) ---
+#
+# 1. PARSE THE SPEC
+#    - rule_name: from first # heading, normalized to snake_case
+#    - description: paragraph after heading (for problemMessage and doc comments)
+#    - scope: test_only → testOnly: true; include_tests → includeTests: true; else default
+#    - exceptions: use for shouldSkipFile or visitor logic in the analyzer
+#    - bad_examples / good_examples: use to implement and test the analyzer
+#
+# 2. CREATE THE ANALYZER
+#    File: lib/core/analyzers/<rule_name>_analyzer.dart
+#    - Extend BaseAnalyzer
+#    - Implement: ruleName, problemMessage, correctionMessage
+#    - Implement analyze(CompilationUnit) and optionally analyzeWithResolver(CompilationUnit, resolver)
+#    - Use a RecursiveAstVisitor (or similar) to find nodes matching the "Bad" examples
+#    - For each violation call createIssue(node) or createIssue(node, customMessage: ...)
+#    - If exceptions were specified, implement shouldSkipFile(String path) or equivalent
+#    Reference: lib/core/analyzers/forbid_datetime_now_analyzer.dart
+#
+# 3. CREATE THE RULE CLASS
+#    File: lib/custom_lint_rules/<rule_name>.dart
+#    - Extend BaseLintRule
+#    - Constructor: super(BaseLintRule.createLintCode(_analyzer), testOnly: ... | includeTests: ...)
+#      Use testOnly: true if scope is test_only; includeTests: true if scope is include_tests; else omit
+#    - static final _analyzer = <PascalCaseRuleName>Analyzer();
+#    - @override BaseAnalyzer get analyzer => _analyzer;
+#    - Add doc comment from spec description
+#    Reference: lib/custom_lint_rules/forbid_datetime_now.dart
+#
+# 4. REGISTER THE RULE
+#    File: lib/ripplearc_linter.dart
+#    - Add: import 'custom_lint_rules/<rule_name>.dart';
+#    - In getLintRules(...), add <PascalCaseRuleClass>() to the returned list (alphabetical order optional)
+#
+# 5. (RECOMMENDED) ADD TESTS
+#    File: test/custom_lint_rules/<rule_name>_test.dart
+#    - Use parseString, TestCustomLintResolver, TestErrorReporter, TestCustomLintContext
+#    - At least one test that expects a violation (from Bad example) and one that expects no violation (from Good example)
+#    Reference: test/custom_lint_rules/forbid_datetime_now_test.dart
+#
+# 6. (OPTIONAL) ADD EXAMPLE AND DOCS
+#    - example/example_<rule_name>_rule.dart — Bad/Good code with // LINT and // OK comments
+#    - docs/<rule_name>.md — same structure as docs/forbid_datetime_now.md
+#
+# 7. AFTER CREATING ALL FILES
+#    Tell the user to run this script to create the branch and PR:
+#      ./scripts/create_linter_rule_from_spec.sh <rule_name> [base_branch]
+#    Or run it yourself if you have terminal access.
+#
+# =============================================================================
+# END AGENT INSTRUCTIONS
+# =============================================================================
+
+set -e
+
+RULE_NAME="${1:-}"
+BASE_BRANCH="${2:-main}"
+
+if [ -z "$RULE_NAME" ]; then
+  echo "Usage: $0 <rule_name> [base_branch]"
+  echo "Example: $0 forbid_foo main"
+  echo ""
+  echo "Rule name must be snake_case (e.g. forbid_datetime_now)."
+  echo "After the Cursor agent has created the analyzer, rule, and registration,"
+  echo "run this script to create the branch, commit, push, and open a PR."
+  exit 1
+fi
+
+# Normalize to snake_case (no spaces, lowercase)
+RULE_NAME=$(echo "$RULE_NAME" | tr '[:upper:]' '[:lower:]' | tr -s ' ' '_' | tr -d '-')
+BRANCH_NAME="rule/${RULE_NAME}"
+
+# Ensure we're in repo root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Check for uncommitted changes
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Creating branch and committing current changes..."
+else
+  echo "No changes to commit. Have you created the analyzer and rule files?"
+  echo "Expected files (at least):"
+  echo "  lib/core/analyzers/${RULE_NAME}_analyzer.dart"
+  echo "  lib/custom_lint_rules/${RULE_NAME}.dart"
+  echo "  lib/ripplearc_linter.dart (updated)"
+  exit 1
+fi
+
+# Create a new branch from current HEAD (keeps all new/edited files in working tree)
+if git rev-parse --verify "$BRANCH_NAME" >/dev/null 2>&1; then
+  git checkout "$BRANCH_NAME"
+else
+  git checkout -b "$BRANCH_NAME"
+fi
+
+# Stage the expected rule-related files (if they exist)
+for f in \
+  "lib/core/analyzers/${RULE_NAME}_analyzer.dart" \
+  "lib/custom_lint_rules/${RULE_NAME}.dart" \
+  "lib/ripplearc_linter.dart" \
+  "test/custom_lint_rules/${RULE_NAME}_test.dart" \
+  "example/example_${RULE_NAME}_rule.dart" \
+  "docs/${RULE_NAME}.md"; do
+  if [ -f "$f" ]; then
+    git add "$f"
+  fi
+done
+
+# Also stage any other modified files (e.g. custom_lint_package, standalone_checker)
+git add -u lib/ bin/ test/custom_lint_rules/ example/ docs/ 2>/dev/null || true
+
+# Commit
+git status
+echo ""
+read -p "Commit with message 'Add ${RULE_NAME} linter rule'? [Y/n] " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Nn]$ ]]; then
+  git commit -m "Add ${RULE_NAME} linter rule"
+else
+  echo "Aborted. You can commit manually."
+  exit 0
+fi
+
+# Push
+echo "Pushing branch $BRANCH_NAME..."
+git push -u origin "$BRANCH_NAME"
+
+# Open PR with gh if available
+if command -v gh >/dev/null 2>&1; then
+  echo "Creating pull request..."
+  gh pr create --base "$BASE_BRANCH" --head "$BRANCH_NAME" \
+    --title "Add ${RULE_NAME} linter rule" \
+    --body "Adds the \`${RULE_NAME}\` custom linter rule.
+
+- Analyzer: \`lib/core/analyzers/${RULE_NAME}_analyzer.dart\`
+- Rule: \`lib/custom_lint_rules/${RULE_NAME}.dart\`
+- Registered in \`lib/ripplearc_linter.dart\`
+
+Created via \`scripts/create_linter_rule_from_spec.sh\`."
+else
+  echo "GitHub CLI (gh) not found. Create the PR manually:"
+  echo "  Open: $(git remote get-url origin | sed 's/\.git$//')/compare/${BASE_BRANCH}...${BRANCH_NAME}"
+fi
+
+echo "Done."

--- a/scripts/create_linter_rule_from_spec.sh
+++ b/scripts/create_linter_rule_from_spec.sh
@@ -96,6 +96,27 @@
 # END AGENT INSTRUCTIONS
 # =============================================================================
 
+# Open GitHub compare/PR page in the default browser (when gh is not installed)
+_open_pr_in_browser() {
+  local base="$1"
+  local head="$2"
+  local origin_url
+  origin_url=$(git remote get-url origin 2>/dev/null | sed 's/\.git$//')
+  [ -z "$origin_url" ] && return 1
+  local pr_url="${origin_url}/compare/${base}...${head}"
+  echo "Open in browser to create the PR: $pr_url"
+  if command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$pr_url" 2>/dev/null && return 0
+  fi
+  if command -v open >/dev/null 2>&1; then
+    open "$pr_url" 2>/dev/null && return 0
+  fi
+  if command -v start >/dev/null 2>&1; then
+    start "$pr_url" 2>/dev/null && return 0
+  fi
+  return 1
+}
+
 set -e
 
 RULE_NAME="${1:-}"
@@ -120,15 +141,47 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
-# Check for uncommitted changes
-if [ -n "$(git status --porcelain)" ]; then
-  echo "Creating branch and committing current changes..."
-else
+# If no uncommitted changes, check if we're on the rule branch and already pushed → just create PR
+if [ -z "$(git status --porcelain)" ]; then
+  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  if [ "$CURRENT_BRANCH" = "$BRANCH_NAME" ]; then
+    # On the rule branch and clean. Push if needed, then create PR.
+    git push -u origin "$BRANCH_NAME" 2>/dev/null || true
+    if command -v gh >/dev/null 2>&1; then
+      if gh pr view --head "$BRANCH_NAME" >/dev/null 2>&1; then
+        echo "A PR for branch $BRANCH_NAME already exists."
+        gh pr view --web 2>/dev/null || true
+      else
+        echo "Creating pull request for existing branch $BRANCH_NAME..."
+        gh pr create --base "$BASE_BRANCH" --head "$BRANCH_NAME" \
+          --title "Add ${RULE_NAME} linter rule" \
+          --body "Adds the \`${RULE_NAME}\` custom linter rule.
+
+- Analyzer: \`lib/core/analyzers/${RULE_NAME}_analyzer.dart\`
+- Rule: \`lib/custom_lint_rules/${RULE_NAME}.dart\`
+- Registered in \`lib/ripplearc_linter.dart\`
+
+Created via \`scripts/create_linter_rule_from_spec.sh\`."
+        echo "Done."
+      fi
+      exit 0
+    else
+      echo "GitHub CLI (gh) not found. Opening GitHub in browser to create the PR..."
+      _open_pr_in_browser "$BASE_BRANCH" "$BRANCH_NAME" || echo "  Open: $(git remote get-url origin | sed 's/\.git$//')/compare/${BASE_BRANCH}...${BRANCH_NAME}"
+      exit 0
+    fi
+  fi
+  # Not on the rule branch, and no changes
   echo "No changes to commit. Have you created the analyzer and rule files?"
   echo "Expected files (at least):"
   echo "  lib/core/analyzers/${RULE_NAME}_analyzer.dart"
   echo "  lib/custom_lint_rules/${RULE_NAME}.dart"
   echo "  lib/ripplearc_linter.dart (updated)"
+  echo ""
+  echo "If you already committed and pushed to branch $BRANCH_NAME, run:"
+  echo "  git checkout $BRANCH_NAME"
+  echo "  $0 $RULE_NAME $BASE_BRANCH"
+  echo "to create the PR only."
   exit 1
 fi
 
@@ -152,8 +205,8 @@ for f in \
   fi
 done
 
-# Also stage any other modified files (e.g. custom_lint_package, standalone_checker)
-git add -u lib/ bin/ test/custom_lint_rules/ example/ docs/ 2>/dev/null || true
+# Stage every change under key dirs (rule files, script, spec, package, checker, tests, docs)
+git add -A lib/ bin/ test/custom_lint_rules/ example/ docs/ scripts/ rule_specs/ 2>/dev/null || true
 
 # Commit
 git status
@@ -184,8 +237,8 @@ if command -v gh >/dev/null 2>&1; then
 
 Created via \`scripts/create_linter_rule_from_spec.sh\`."
 else
-  echo "GitHub CLI (gh) not found. Create the PR manually:"
-  echo "  Open: $(git remote get-url origin | sed 's/\.git$//')/compare/${BASE_BRANCH}...${BRANCH_NAME}"
+  echo "GitHub CLI (gh) not found. Opening GitHub in browser to create the PR..."
+  _open_pr_in_browser "$BASE_BRANCH" "$BRANCH_NAME" || echo "  Open: $(git remote get-url origin | sed 's/\.git$//')/compare/${BASE_BRANCH}...${BRANCH_NAME}"
 fi
 
 echo "Done."


### PR DESCRIPTION
This pull request introduces a comprehensive, semi-automated workflow for adding new custom linter rules using the Cursor agent and a new shell script. It provides both documentation and tooling to streamline the process from writing a rule specification to generating code, committing changes, and opening a pull request. The main changes are grouped into documentation and automation/tooling improvements:

**Documentation improvements:**

* Added `docs/wiki-create-custom-linter-rule-with-agent.md`, a detailed guide explaining how to create a custom linter rule using the Cursor agent and the new script, including the required rule spec format, usage steps, troubleshooting, and file locations.

**Automation and tooling:**

* Introduced `scripts/create_linter_rule_from_spec.sh`, a shell script that:
  - Contains detailed instructions for the Cursor agent on how to generate all required files from a rule spec.
  - Automates branch creation, staging, committing, pushing, and PR creation for new linter rules.
  - Handles both command-line and GitHub CLI (`gh`) workflows, including fallback to opening PRs in the browser if `gh` is unavailable.
* The script expects the agent to generate files in specific locations and with a defined structure, ensuring consistency and reducing manual steps.

These changes together enable a repeatable, agent-driven process for expanding the project's custom lint rules with minimal manual intervention.