### PR TITLE
Add avoid_static_colors_agent_test linter rule

### DIFF
--- a/docs/avoid_static_colors_agent_test.md
+++ b/docs/avoid_static_colors_agent_test.md
@@ -1,0 +1,136 @@
+# avoid_static_colors_agent_test
+
+**Type**: Linter Rule  
+**Severity**: Warning  
+**Category**: Design / Theme  
+**Scope**: Production and Test files
+
+## Overview
+
+Enforces theme-context-based color access for proper light/dark mode support. This rule flags static color usage that breaks theme switching (e.g. `Colors.white`, `CoreTextColors.headline`, `Color(0xFF...)`). Use `Theme.of(context).extension<AppColorsExtension>()` instead.
+
+## Why This Rule Exists
+
+Static color references break proper theme support in Flutter applications because:
+
+1. **Theme switching fails**: Hard-coded colors don't change when the user switches between light and dark modes
+2. **Accessibility issues**: Users with accessibility needs (high contrast, color blindness) can't customize colors
+3. **Maintenance burden**: Changing colors requires finding and updating every hard-coded reference
+4. **Inconsistent UI**: Different parts of the app may use slightly different color values for the "same" color
+
+By accessing colors through `Theme.of(context).extension<AppColorsExtension>()`, your app:
+- Automatically supports light/dark mode
+- Respects user accessibility preferences
+- Maintains consistent colors across the entire application
+- Makes global color changes trivial (just update the theme)
+
+## Bad Examples
+
+```dart
+// Static CoreUI tokens
+Text(style: TextStyle(color: CoreTextColors.headline));
+
+// Flutter Colors class
+Container(color: Colors.white);
+Container(color: Colors.grey[700]);
+
+// CupertinoColors
+Container(color: CupertinoColors.systemRed);
+
+// Direct Color definitions
+Container(color: Color(0xFF015B7C));
+Container(color: Color.fromARGB(255, 0, 0, 0));
+
+// Prefixed imports
+Container(color: material.Colors.red);
+```
+
+## Good Examples
+
+```dart
+final colors = Theme.of(context).extension<AppColorsExtension>()!;
+
+Text(style: TextStyle(color: colors.textHeadline));
+Container(color: colors.pageBackground);
+Container(color: colors.lineLight);
+```
+
+## Exceptions
+
+This rule automatically skips files in the following locations:
+- `/lib/src/theme/` - Theme definition files
+- `/test/theme/` - Theme-related test files
+
+These directories are excluded because they typically define the theme colors themselves and need to reference static color values.
+
+## How to Fix
+
+1. **Define your colors in a theme extension**:
+
+```dart
+class AppColorsExtension extends ThemeExtension<AppColorsExtension> {
+  final Color textHeadline;
+  final Color pageBackground;
+  final Color lineLight;
+
+  AppColorsExtension({
+    required this.textHeadline,
+    required this.pageBackground,
+    required this.lineLight,
+  });
+
+  @override
+  ThemeExtension<AppColorsExtension> copyWith({...}) { ... }
+
+  @override
+  ThemeExtension<AppColorsExtension> lerp(...) { ... }
+}
+```
+
+2. **Register the extension with your themes**:
+
+```dart
+final lightTheme = ThemeData.light().copyWith(
+  extensions: [
+    AppColorsExtension(
+      textHeadline: Color(0xFF000000),
+      pageBackground: Color(0xFFFFFFFF),
+      lineLight: Color(0xFFE0E0E0),
+    ),
+  ],
+);
+
+final darkTheme = ThemeData.dark().copyWith(
+  extensions: [
+    AppColorsExtension(
+      textHeadline: Color(0xFFFFFFFF),
+      pageBackground: Color(0xFF121212),
+      lineLight: Color(0xFF2C2C2C),
+    ),
+  ],
+);
+```
+
+3. **Access colors via the theme**:
+
+```dart
+@override
+Widget build(BuildContext context) {
+  final colors = Theme.of(context).extension<AppColorsExtension>()!;
+  
+  return Text(
+    'Hello',
+    style: TextStyle(color: colors.textHeadline),
+  );
+}
+```
+
+## Related Rules
+
+- `avoid_static_typography` - Enforces theme-based typography access
+- `avoid_static_colors` - The production version of this rule
+
+## Additional Resources
+
+- [Flutter Theming Documentation](https://docs.flutter.dev/cookbook/design/themes)
+- [Theme Extensions Guide](https://api.flutter.dev/flutter/material/ThemeExtension-class.html)

--- a/example/example_avoid_static_colors_agent_test_rule.dart
+++ b/example/example_avoid_static_colors_agent_test_rule.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
+
+// BAD: Static CoreUI tokens
+class BadCoreUITokens extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      'Hello',
+      // LINT: Static color token "CoreTextColors.headline" detected
+      style: TextStyle(color: CoreTextColors.headline),
+    );
+  }
+}
+
+// BAD: Flutter Colors class
+class BadFlutterColors extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        // LINT: Flutter Colors class usage "Colors.white" detected
+        Container(color: Colors.white),
+        // LINT: Flutter Colors class index access "Colors.grey[...]" detected
+        Container(color: Colors.grey[700]),
+      ],
+    );
+  }
+}
+
+// BAD: CupertinoColors
+class BadCupertinoColors extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    // LINT: Flutter CupertinoColors class usage "CupertinoColors.systemRed" detected
+    return Container(color: CupertinoColors.systemRed);
+  }
+}
+
+// BAD: Direct Color definitions
+class BadDirectColors extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        // LINT: Direct color definition "Color(0xFF015B7C)" detected
+        Container(color: Color(0xFF015B7C)),
+        // LINT: Direct color definition "Color.fromARGB(...)" detected
+        Container(color: Color.fromARGB(255, 0, 0, 0)),
+      ],
+    );
+  }
+}
+
+// BAD: Prefixed imports
+import 'package:flutter/material.dart' as material;
+
+class BadPrefixedImports extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    // LINT: Flutter Colors class usage (via prefixed import) detected
+    return Container(color: material.Colors.red);
+  }
+}
+
+// GOOD: Theme-based color access
+class GoodThemeColors extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    // OK: Using theme extension for color access
+    final colors = Theme.of(context).extension<AppColorsExtension>()!;
+    
+    return Column(
+      children: [
+        // OK: Color from theme extension
+        Text(
+          'Hello',
+          style: TextStyle(color: colors.textHeadline),
+        ),
+        // OK: Color from theme extension
+        Container(color: colors.pageBackground),
+        // OK: Color from theme extension
+        Container(color: colors.lineLight),
+      ],
+    );
+  }
+}
+
+// Example CoreUI color classes (for demonstration)
+class CoreTextColors {
+  static const headline = Color(0xFF000000);
+  static const body = Color(0xFF333333);
+}
+
+class CoreBackgroundColors {
+  static const pageBackground = Color(0xFFFFFFFF);
+}
+
+// Example theme extension (for demonstration)
+class AppColorsExtension extends ThemeExtension<AppColorsExtension> {
+  final Color textHeadline;
+  final Color pageBackground;
+  final Color lineLight;
+
+  AppColorsExtension({
+    required this.textHeadline,
+    required this.pageBackground,
+    required this.lineLight,
+  });
+
+  @override
+  ThemeExtension<AppColorsExtension> copyWith({
+    Color? textHeadline,
+    Color? pageBackground,
+    Color? lineLight,
+  }) {
+    return AppColorsExtension(
+      textHeadline: textHeadline ?? this.textHeadline,
+      pageBackground: pageBackground ?? this.pageBackground,
+      lineLight: lineLight ?? this.lineLight,
+    );
+  }
+
+  @override
+  ThemeExtension<AppColorsExtension> lerp(
+    ThemeExtension<AppColorsExtension>? other,
+    double t,
+  ) {
+    if (other is! AppColorsExtension) return this;
+    return AppColorsExtension(
+      textHeadline: Color.lerp(textHeadline, other.textHeadline, t)!,
+      pageBackground: Color.lerp(pageBackground, other.pageBackground, t)!,
+      lineLight: Color.lerp(lineLight, other.lineLight, t)!,
+    );
+  }
+}

--- a/lib/core/analyzers/avoid_static_colors_agent_test_analyzer.dart
+++ b/lib/core/analyzers/avoid_static_colors_agent_test_analyzer.dart
@@ -1,0 +1,341 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'base_analyzer.dart';
+import '../models/lint_issue.dart';
+
+/// Analyzer that enforces theme-context-based color access.
+///
+/// This rule flags static color tokens and direct color definitions that break
+/// theme switching (light/dark mode). Colors should be accessed via
+/// `Theme.of(context).extension<AppColorsExtension>()` instead.
+///
+/// Violations detected:
+/// - CoreUI static color token classes (CoreTextColors, CoreBackgroundColors, etc.)
+/// - Flutter's Colors and CupertinoColors classes
+/// - Direct Color definitions (hex, decimal, fromARGB, fromRGBO)
+/// - Prefixed imports (e.g., MaterialUI.Colors.red)
+///
+/// Example of code that triggers this rule:
+/// ```dart
+/// // Using static CoreUI tokens
+/// color: CoreTextColors.headline,
+/// backgroundColor: CoreBackgroundColors.pageBackground,
+///
+/// // Using Flutter Colors class
+/// color: Colors.white,
+/// color: Colors.grey[700],
+/// color: CupertinoColors.systemRed,
+///
+/// // Using direct colors (hex or decimal)
+/// color: Color(0xFF015B7C),
+/// color: Color(4278190080),
+/// color: Color.fromARGB(255, 0, 0, 0),
+///
+/// // Using prefixed imports
+/// color: MaterialUI.Colors.red,
+/// ```
+///
+/// Example of correct code:
+/// ```dart
+/// final colors = Theme.of(context).extension<AppColorsExtension>()!;
+/// color: colors.textHeadline,
+/// backgroundColor: colors.pageBackground,
+/// ```
+class AvoidStaticColorsAgentTestAnalyzer extends BaseAnalyzer {
+  static final _coreColorPattern = RegExp(r'^Core\w+Colors$');
+
+  static const _flutterColorClasses = [
+    'Colors',
+    'CupertinoColors',
+  ];
+
+  static const _colorFactoryMethods = ['fromARGB', 'fromRGBO'];
+  static const _colorClassName = 'Color';
+
+  @override
+  String get ruleName => 'avoid_static_colors_agent_test';
+
+  @override
+  String get problemMessage =>
+      'Static color usage detected. Use Theme.of(context).extension<AppColorsExtension>() instead.';
+
+  @override
+  String get correctionMessage =>
+      'Access colors via Theme.of(context).extension<AppColorsExtension>()! for proper light/dark mode support.';
+
+  @override
+  List<LintIssue> analyze(CompilationUnit unit) {
+    final visitor = _StaticColorVisitor(this);
+    unit.accept(visitor);
+    return visitor.issues;
+  }
+
+  @override
+  List<LintIssue> analyzeWithResolver(CompilationUnit unit, dynamic resolver) {
+    final path = resolver.path ?? '';
+    if (_shouldSkipFile(path)) {
+      return [];
+    }
+    return analyze(unit);
+  }
+
+  bool _shouldSkipFile(String path) {
+    const skipSegments = ['/lib/src/theme/', '/test/theme/'];
+    final normalized = path.replaceAll('\\', '/');
+    return skipSegments.any(normalized.contains);
+  }
+
+  bool isCoreColorClass(String identifier) {
+    return _coreColorPattern.hasMatch(identifier);
+  }
+
+  bool isFlutterColorClass(String identifier) {
+    return _flutterColorClasses.contains(identifier);
+  }
+}
+
+class _StaticColorVisitor extends RecursiveAstVisitor<void> {
+  final AvoidStaticColorsAgentTestAnalyzer analyzer;
+  final List<LintIssue> issues = [];
+
+  _StaticColorVisitor(this.analyzer);
+
+  @override
+  void visitPrefixedIdentifier(PrefixedIdentifier node) {
+    final prefix = node.prefix.name;
+
+    if (node.parent is IndexExpression) {
+      super.visitPrefixedIdentifier(node);
+      return;
+    }
+
+    if (analyzer.isCoreColorClass(prefix)) {
+      issues.add(analyzer.createIssue(
+        node,
+        customMessage:
+            'Static color token "$prefix.${node.identifier.name}" detected. '
+            'Use Theme.of(context).extension<AppColorsExtension>() instead.',
+      ));
+    }
+
+    if (analyzer.isFlutterColorClass(prefix)) {
+      issues.add(analyzer.createIssue(
+        node,
+        customMessage:
+            'Flutter $prefix class usage "$prefix.${node.identifier.name}" detected. '
+            'Use Theme.of(context).extension<AppColorsExtension>() instead.',
+      ));
+    }
+
+    super.visitPrefixedIdentifier(node);
+  }
+
+  @override
+  void visitPropertyAccess(PropertyAccess node) {
+    if (node.parent is IndexExpression) {
+      super.visitPropertyAccess(node);
+      return;
+    }
+
+    final target = node.target;
+    if (target is PrefixedIdentifier) {
+      final colorClass = target.identifier.name;
+      if (analyzer.isFlutterColorClass(colorClass)) {
+        issues.add(analyzer.createIssue(
+          node,
+          customMessage:
+              'Flutter $colorClass class usage (via prefixed import) "${node.toSource()}" detected. '
+              'Use Theme.of(context).extension<AppColorsExtension>() instead.',
+        ));
+      }
+    }
+
+    super.visitPropertyAccess(node);
+  }
+
+  @override
+  void visitIndexExpression(IndexExpression node) {
+    final target = node.target;
+    if (target is PrefixedIdentifier && analyzer.isFlutterColorClass(target.prefix.name)) {
+      final colorClass = target.prefix.name;
+      issues.add(analyzer.createIssue(
+        node,
+        customMessage:
+            'Flutter $colorClass class index access "$colorClass.${target.identifier.name}[...]" detected. '
+            'Use Theme.of(context).extension<AppColorsExtension>() instead.',
+      ));
+    }
+
+    if (target is PropertyAccess) {
+      final propertyTarget = target.target;
+      if (propertyTarget is PrefixedIdentifier) {
+        final colorClass = propertyTarget.identifier.name;
+        if (analyzer.isFlutterColorClass(colorClass)) {
+          issues.add(analyzer.createIssue(
+            node,
+            customMessage:
+                'Flutter $colorClass class index access (via prefixed import) "${node.toSource()}" detected. '
+                'Use Theme.of(context).extension<AppColorsExtension>() instead.',
+          ));
+        }
+      }
+    }
+
+    super.visitIndexExpression(node);
+  }
+
+  @override
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    final constructorName = node.constructorName;
+    final typeName = constructorName.type.name2.lexeme;
+
+    if (typeName == AvoidStaticColorsAgentTestAnalyzer._colorClassName) {
+      final constructorNameElement = constructorName.name?.name;
+
+      if (constructorNameElement == null) {
+        final arguments = node.argumentList.arguments;
+        if (arguments.isNotEmpty) {
+          final firstArg = arguments.first;
+          if (firstArg is IntegerLiteral) {
+            final argString = firstArg.toSource();
+            issues.add(analyzer.createIssue(
+              node,
+              customMessage:
+                  'Direct color definition "Color($argString)" detected. '
+                  'Use Theme.of(context).extension<AppColorsExtension>() instead.',
+            ));
+          }
+        }
+      } else if (constructorNameElement == 'fromARGB' ||
+          constructorNameElement == 'fromRGBO') {
+        issues.add(analyzer.createIssue(
+          node,
+          customMessage:
+              'Direct color definition "Color.$constructorNameElement(...)" detected. '
+              'Use Theme.of(context).extension<AppColorsExtension>() instead.',
+        ));
+      }
+    }
+
+    super.visitInstanceCreationExpression(node);
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    final target = node.target;
+    final methodName = node.methodName.name;
+
+    if (target == null &&
+        methodName == AvoidStaticColorsAgentTestAnalyzer._colorClassName) {
+      final arguments = node.argumentList.arguments;
+      if (arguments.isNotEmpty) {
+        final firstArg = arguments.first;
+        if (firstArg is IntegerLiteral) {
+          final argString = firstArg.toSource();
+          issues.add(analyzer.createIssue(
+            node,
+            customMessage:
+                'Direct color definition "Color($argString)" detected. '
+                'Use Theme.of(context).extension<AppColorsExtension>() instead.',
+          ));
+        }
+      }
+    }
+
+    if (target is SimpleIdentifier &&
+        methodName == AvoidStaticColorsAgentTestAnalyzer._colorClassName) {
+      final arguments = node.argumentList.arguments;
+      if (arguments.isNotEmpty) {
+        final firstArg = arguments.first;
+        if (firstArg is IntegerLiteral) {
+          issues.add(analyzer.createIssue(
+            node,
+            customMessage:
+                'Direct color definition (via prefixed import) "${node.toSource()}" detected. '
+                'Use Theme.of(context).extension<AppColorsExtension>() instead.',
+          ));
+        }
+      }
+    }
+
+    if (target is SimpleIdentifier &&
+        target.name == AvoidStaticColorsAgentTestAnalyzer._colorClassName) {
+      if (AvoidStaticColorsAgentTestAnalyzer._colorFactoryMethods.contains(methodName)) {
+        issues.add(analyzer.createIssue(
+          node,
+          customMessage:
+              'Direct color definition "Color.$methodName(...)" detected. '
+              'Use Theme.of(context).extension<AppColorsExtension>() instead.',
+        ));
+      }
+    }
+
+    if (target is PrefixedIdentifier &&
+        target.identifier.name == AvoidStaticColorsAgentTestAnalyzer._colorClassName) {
+      if (AvoidStaticColorsAgentTestAnalyzer._colorFactoryMethods.contains(methodName)) {
+        issues.add(analyzer.createIssue(
+          node,
+          customMessage:
+              'Direct color definition (via prefixed import) "${node.toSource()}" detected. '
+              'Use Theme.of(context).extension<AppColorsExtension>() instead.',
+        ));
+      }
+    }
+
+    if (target is PrefixedIdentifier &&
+        analyzer.isFlutterColorClass(target.prefix.name)) {
+      super.visitMethodInvocation(node);
+      return;
+    }
+
+    if (target is InstanceCreationExpression) {
+      final typeName = target.constructorName.type.name2.lexeme;
+      if (typeName == AvoidStaticColorsAgentTestAnalyzer._colorClassName) {
+        super.visitMethodInvocation(node);
+        return;
+      }
+    }
+
+    super.visitMethodInvocation(node);
+  }
+
+  @override
+  void visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
+    final function = node.function;
+
+    if (function is SimpleIdentifier &&
+        function.name == AvoidStaticColorsAgentTestAnalyzer._colorClassName) {
+      final arguments = node.argumentList.arguments;
+      if (arguments.isNotEmpty) {
+        final firstArg = arguments.first;
+        if (firstArg is IntegerLiteral) {
+          final argString = firstArg.toSource();
+          issues.add(analyzer.createIssue(
+            node,
+            customMessage:
+                'Direct color definition "Color($argString)" detected. '
+                'Use Theme.of(context).extension<AppColorsExtension>() instead.',
+          ));
+        }
+      }
+    }
+
+    if (function is PrefixedIdentifier &&
+        function.identifier.name == AvoidStaticColorsAgentTestAnalyzer._colorClassName) {
+      final arguments = node.argumentList.arguments;
+      if (arguments.isNotEmpty) {
+        final firstArg = arguments.first;
+        if (firstArg is IntegerLiteral) {
+          issues.add(analyzer.createIssue(
+            node,
+            customMessage:
+                'Direct color definition (via prefixed import) "${node.toSource()}" detected. '
+                'Use Theme.of(context).extension<AppColorsExtension>() instead.',
+          ));
+        }
+      }
+    }
+
+    super.visitFunctionExpressionInvocation(node);
+  }
+}

--- a/lib/custom_lint_rules/avoid_static_colors_agent_test.dart
+++ b/lib/custom_lint_rules/avoid_static_colors_agent_test.dart
@@ -1,0 +1,47 @@
+import '../core/base_lint_rule.dart';
+import '../core/analyzers/avoid_static_colors_agent_test_analyzer.dart';
+import '../core/analyzers/base_analyzer.dart';
+
+/// Enforces theme-context-based color access for proper light/dark mode support.
+///
+/// This rule flags static color usage that breaks theme switching (e.g. `Colors.white`,
+/// `CoreTextColors.headline`, `Color(0xFF...)`). Use
+/// `Theme.of(context).extension<AppColorsExtension>()` instead.
+///
+/// Example of code that triggers this rule:
+/// ```dart
+/// // Static CoreUI tokens
+/// Text(style: TextStyle(color: CoreTextColors.headline));
+///
+/// // Flutter Colors class
+/// Container(color: Colors.white);
+/// Container(color: Colors.grey[700]);
+///
+/// // CupertinoColors
+/// Container(color: CupertinoColors.systemRed);
+///
+/// // Direct Color definitions
+/// Container(color: Color(0xFF015B7C));
+/// Container(color: Color.fromARGB(255, 0, 0, 0));
+///
+/// // Prefixed imports
+/// Container(color: material.Colors.red);
+/// ```
+///
+/// Example of correct usage:
+/// ```dart
+/// final colors = Theme.of(context).extension<AppColorsExtension>()!;
+///
+/// Text(style: TextStyle(color: colors.textHeadline));
+/// Container(color: colors.pageBackground);
+/// Container(color: colors.lineLight);
+/// ```
+class AvoidStaticColorsAgentTest extends BaseLintRule {
+  AvoidStaticColorsAgentTest()
+      : super(BaseLintRule.createLintCode(_analyzer), includeTests: true);
+
+  static final _analyzer = AvoidStaticColorsAgentTestAnalyzer();
+
+  @override
+  BaseAnalyzer get analyzer => _analyzer;
+}

--- a/lib/ripplearc_linter.dart
+++ b/lib/ripplearc_linter.dart
@@ -1,5 +1,6 @@
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'custom_lint_rules/avoid_static_colors.dart';
+import 'custom_lint_rules/avoid_static_colors_agent_test.dart';
 import 'custom_lint_rules/avoid_static_typography.dart';
 import 'custom_lint_rules/avoid_test_timeouts.dart';
 import 'custom_lint_rules/no_direct_instantiation.dart';
@@ -27,6 +28,7 @@ class _RipplearcLintRules extends PluginBase {
   @override
   List<LintRule> getLintRules(CustomLintConfigs configs) => [
     AvoidStaticColors(),
+    AvoidStaticColorsAgentTest(),
     AvoidStaticTypography(),
     ForbidForcedUnwrapping(),
     ForbidHelperUtilNaming(),

--- a/rule_specs/avoid_static_colors_agent_test.md
+++ b/rule_specs/avoid_static_colors_agent_test.md
@@ -1,0 +1,34 @@
+# avoid_static_colors_agent_test
+
+Enforces theme-context-based color access for proper light/dark mode support. This rule flags static color usage that breaks theme switching (e.g. `Colors.white`, `CoreTextColors.headline`, `Color(0xFF...)`). Use `Theme.of(context).extension<AppColorsExtension>()` instead.
+
+**Scope**: include_tests
+
+## Bad
+```dart
+// Static CoreUI tokens
+Text(style: TextStyle(color: CoreTextColors.headline));
+
+// Flutter Colors class
+Container(color: Colors.white);
+Container(color: Colors.grey[700]);
+
+// CupertinoColors
+Container(color: CupertinoColors.systemRed);
+
+// Direct Color definitions
+Container(color: Color(0xFF015B7C));
+Container(color: Color.fromARGB(255, 0, 0, 0));
+
+// Prefixed imports
+Container(color: material.Colors.red);
+```
+
+## Good
+```dart
+final colors = Theme.of(context).extension<AppColorsExtension>()!;
+
+Text(style: TextStyle(color: colors.textHeadline));
+Container(color: colors.pageBackground);
+Container(color: colors.lineLight);
+```

--- a/test/custom_lint_rules/avoid_static_colors_agent_test_test.dart
+++ b/test/custom_lint_rules/avoid_static_colors_agent_test_test.dart
@@ -1,0 +1,375 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:ripplearc_linter/custom_lint_rules/avoid_static_colors_agent_test.dart';
+import 'package:test/test.dart';
+import '../utils/custom_lint_resolver.dart';
+import '../utils/test_error_reporter.dart';
+
+void main() {
+  group('AvoidStaticColorsAgentTest', () {
+    late AvoidStaticColorsAgentTest rule;
+    late TestErrorReporter reporter;
+    late CompilationUnit unit;
+
+    setUp(() {
+      rule = AvoidStaticColorsAgentTest();
+      reporter = TestErrorReporter();
+    });
+
+    Future<void> analyzeCode(String sourceCode, {required String path}) async {
+      final parseResult = parseString(content: sourceCode);
+      unit = parseResult.unit;
+      rule.run(
+        TestCustomLintResolver(unit, path: path),
+        reporter,
+        TestCustomLintContext(unit),
+      );
+    }
+
+    group('CoreUI static color tokens - Bad examples', () {
+      test('should flag CoreTextColors usage', () async {
+        const source = '''
+        import 'package:flutter/material.dart';
+        
+        void main() {
+          final style = TextStyle(color: CoreTextColors.headline);
+        }
+        
+        class CoreTextColors {
+          static const headline = Color(0xFF000000);
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/my_widget.dart');
+        expect(reporter.errors, hasLength(1));
+        expect(reporter.errors.first.message, contains('CoreTextColors'));
+      });
+
+      test('should flag CoreBackgroundColors usage', () async {
+        const source = '''
+        import 'package:flutter/material.dart';
+        
+        void main() {
+          final color = CoreBackgroundColors.pageBackground;
+        }
+        
+        class CoreBackgroundColors {
+          static const pageBackground = Color(0xFFFFFFFF);
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/my_widget.dart');
+        expect(reporter.errors, hasLength(1));
+        expect(reporter.errors.first.message, contains('CoreBackgroundColors'));
+      });
+
+      test('should flag CoreBorderColors usage', () async {
+        const source = '''
+        import 'package:flutter/material.dart';
+        
+        void main() {
+          final color = CoreBorderColors.divider;
+        }
+        
+        class CoreBorderColors {
+          static const divider = Color(0xFFE0E0E0);
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/my_widget.dart');
+        expect(reporter.errors, hasLength(1));
+        expect(reporter.errors.first.message, contains('CoreBorderColors'));
+      });
+    });
+
+    group('Flutter Colors class - Bad examples', () {
+      test('should flag Colors.white usage', () async {
+        const source = '''
+        import 'package:flutter/material.dart';
+        
+        void main() {
+          final widget = Container(color: Colors.white);
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/my_widget.dart');
+        expect(reporter.errors, hasLength(1));
+        expect(reporter.errors.first.message, contains('Colors'));
+      });
+
+      test('should flag Colors with index access', () async {
+        const source = '''
+        import 'package:flutter/material.dart';
+        
+        void main() {
+          final widget = Container(color: Colors.grey[700]);
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/my_widget.dart');
+        expect(reporter.errors, hasLength(1));
+        expect(reporter.errors.first.message, contains('Colors'));
+      });
+
+      test('should flag multiple Colors usage', () async {
+        const source = '''
+        import 'package:flutter/material.dart';
+        
+        void main() {
+          final widget1 = Container(color: Colors.white);
+          final widget2 = Container(color: Colors.black);
+          final widget3 = Container(color: Colors.red);
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/my_widget.dart');
+        expect(reporter.errors, hasLength(3));
+      });
+    });
+
+    group('CupertinoColors - Bad examples', () {
+      test('should flag CupertinoColors.systemRed usage', () async {
+        const source = '''
+        import 'package:flutter/cupertino.dart';
+        
+        void main() {
+          final widget = Container(color: CupertinoColors.systemRed);
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/my_widget.dart');
+        expect(reporter.errors, hasLength(1));
+        expect(reporter.errors.first.message, contains('CupertinoColors'));
+      });
+    });
+
+    group('Direct Color definitions - Bad examples', () {
+      test('should flag Color(0xFF...) usage', () async {
+        const source = '''
+        import 'package:flutter/material.dart';
+        
+        void main() {
+          final widget = Container(color: Color(0xFF015B7C));
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/my_widget.dart');
+        expect(reporter.errors, hasLength(1));
+        expect(reporter.errors.first.message, contains('Direct color definition'));
+      });
+
+      test('should flag Color.fromARGB usage', () async {
+        const source = '''
+        import 'package:flutter/material.dart';
+        
+        void main() {
+          final widget = Container(color: Color.fromARGB(255, 0, 0, 0));
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/my_widget.dart');
+        expect(reporter.errors, hasLength(1));
+        expect(reporter.errors.first.message, contains('Direct color definition'));
+      });
+
+      test('should flag multiple direct color definitions', () async {
+        const source = '''
+        import 'package:flutter/material.dart';
+        
+        void main() {
+          final color1 = Color(0xFF015B7C);
+          final color2 = Color.fromARGB(255, 0, 0, 0);
+          final color3 = Color.fromRGBO(255, 255, 255, 1.0);
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/my_widget.dart');
+        expect(reporter.errors, hasLength(3));
+      });
+    });
+
+    group('Prefixed imports - Bad examples', () {
+      test('should flag prefixed Colors usage', () async {
+        const source = '''
+        import 'package:flutter/material.dart' as material;
+        
+        void main() {
+          final widget = Container(color: material.Colors.red);
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/my_widget.dart');
+        expect(reporter.errors, hasLength(1));
+        expect(reporter.errors.first.message, contains('prefixed import'));
+      });
+    });
+
+    group('Good examples - should not flag', () {
+      test('should not flag Theme.of(context).extension usage', () async {
+        const source = '''
+        import 'package:flutter/material.dart';
+        
+        void main(BuildContext context) {
+          final colors = Theme.of(context).extension<AppColorsExtension>()!;
+          final widget = Text(
+            'Hello',
+            style: TextStyle(color: colors.textHeadline),
+          );
+        }
+        
+        class AppColorsExtension extends ThemeExtension<AppColorsExtension> {
+          final Color textHeadline;
+          AppColorsExtension({required this.textHeadline});
+          
+          @override
+          ThemeExtension<AppColorsExtension> copyWith() => this;
+          
+          @override
+          ThemeExtension<AppColorsExtension> lerp(ThemeExtension<AppColorsExtension>? other, double t) => this;
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/my_widget.dart');
+        expect(reporter.errors, isEmpty);
+      });
+
+      test('should not flag colors accessed from theme extension', () async {
+        const source = '''
+        import 'package:flutter/material.dart';
+        
+        void main(BuildContext context) {
+          final colors = Theme.of(context).extension<AppColorsExtension>()!;
+          final widget1 = Container(color: colors.pageBackground);
+          final widget2 = Container(color: colors.lineLight);
+          final style = TextStyle(color: colors.textHeadline);
+        }
+        
+        class AppColorsExtension extends ThemeExtension<AppColorsExtension> {
+          final Color pageBackground;
+          final Color lineLight;
+          final Color textHeadline;
+          AppColorsExtension({
+            required this.pageBackground,
+            required this.lineLight,
+            required this.textHeadline,
+          });
+          
+          @override
+          ThemeExtension<AppColorsExtension> copyWith() => this;
+          
+          @override
+          ThemeExtension<AppColorsExtension> lerp(ThemeExtension<AppColorsExtension>? other, double t) => this;
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/my_widget.dart');
+        expect(reporter.errors, isEmpty);
+      });
+
+      test('should not flag non-color related classes', () async {
+        const source = '''
+        void main() {
+          final text = MyTextColors.headline;
+          final number = Numbers.one;
+        }
+        
+        class MyTextColors {
+          static const headline = 'headline';
+        }
+        
+        class Numbers {
+          static const one = 1;
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/my_widget.dart');
+        expect(reporter.errors, isEmpty);
+      });
+    });
+
+    group('File scoping', () {
+      test('should flag violations in test files (includeTests: true)', () async {
+        const source = '''
+        import 'package:flutter/material.dart';
+        
+        void main() {
+          final widget = Container(color: Colors.white);
+        }
+        ''';
+        await analyzeCode(source, path: 'test/my_widget_test.dart');
+        expect(reporter.errors, hasLength(1));
+      });
+
+      test('should skip violations in theme directory', () async {
+        const source = '''
+        import 'package:flutter/material.dart';
+        
+        class AppColors {
+          static const primary = Colors.blue;
+          static const secondary = Color(0xFF015B7C);
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/src/theme/app_colors.dart');
+        expect(reporter.errors, isEmpty);
+      });
+
+      test('should skip violations in test/theme directory', () async {
+        const source = '''
+        import 'package:flutter/material.dart';
+        
+        void main() {
+          final color = Colors.white;
+        }
+        ''';
+        await analyzeCode(source, path: 'test/theme/theme_test.dart');
+        expect(reporter.errors, isEmpty);
+      });
+    });
+
+    group('Rule metadata', () {
+      test('should have correct rule name', () {
+        expect(rule.code.name, equals('avoid_static_colors_agent_test'));
+      });
+
+      test('should have problem message mentioning AppColorsExtension', () {
+        expect(rule.code.problemMessage, contains('Theme.of(context).extension<AppColorsExtension>()'));
+      });
+
+      test('should have correction message with guidance', () {
+        expect(rule.code.correctionMessage, contains('Theme.of(context).extension<AppColorsExtension>()'));
+        expect(rule.code.correctionMessage, contains('light/dark mode'));
+      });
+    });
+
+    group('Edge cases', () {
+      test('should flag Colors in nested expressions', () async {
+        const source = '''
+        import 'package:flutter/material.dart';
+        
+        void main() {
+          final color = someCondition ? Colors.white : Colors.black;
+        }
+        
+        final someCondition = true;
+        ''';
+        await analyzeCode(source, path: 'lib/my_widget.dart');
+        expect(reporter.errors, hasLength(2));
+      });
+
+      test('should flag Colors in lambda expressions', () async {
+        const source = '''
+        import 'package:flutter/material.dart';
+        
+        void main() {
+          final getColor = () => Colors.white;
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/my_widget.dart');
+        expect(reporter.errors, hasLength(1));
+      });
+
+      test('should flag CoreTextColors in constructor initializer', () async {
+        const source = '''
+        import 'package:flutter/material.dart';
+        
+        class MyWidget {
+          final Color textColor;
+          MyWidget() : textColor = CoreTextColors.headline;
+        }
+        
+        class CoreTextColors {
+          static const headline = Color(0xFF000000);
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/my_widget.dart');
+        expect(reporter.errors, hasLength(1));
+      });
+    });
+  });
+}


### PR DESCRIPTION
_**This Pr is For test Don't Merge It**_

This pull request introduces a new linter rule, `avoid_static_colors_agent_test`, which enforces the use of theme-context-based color access in Flutter code to ensure proper support for light/dark mode and accessibility. The rule is implemented, documented, and integrated into the linter, with comprehensive examples and rationale provided.

**Key changes include:**

### New Linter Rule Implementation

- Added the `AvoidStaticColorsAgentTestAnalyzer` in `lib/core/analyzers/avoid_static_colors_agent_test_analyzer.dart`, which detects static color usages (such as `Colors.white`, `CoreTextColors.headline`, direct `Color(...)` instantiations, and prefixed color imports) and recommends using `Theme.of(context).extension<AppColorsExtension>()` instead. The analyzer includes logic to skip theme definition files and test files related to themes.
- Introduced the `AvoidStaticColorsAgentTest` lint rule in `lib/custom_lint_rules/avoid_static_colors_agent_test.dart`, connecting the analyzer to the linter infrastructure.

### Documentation and Examples

- Added detailed documentation for the new rule in `docs/avoid_static_colors_agent_test.md`, including the rationale, examples of bad and good code, exceptions, and migration instructions.
- Provided a sample Dart file, `example/example_avoid_static_colors_agent_test_rule.dart`, demonstrating both violations and correct usage of theme-based color access.
- Created a rule specification file, `rule_specs/avoid_static_colors_agent_test.md`, summarizing the rule’s purpose and code examples for both bad and good practices.

### Integration with Linter

- Registered the new rule in the linter by updating `lib/ripplearc_linter.dart` to import and include `AvoidStaticColorsAgentTest` in the list of available lint rules. [[1]](diffhunk://#diff-b288bac189a1395f7465f1b3755548002ced8c289b7f3eb04c273b7b6548c515R3) [[2]](diffhunk://#diff-b288bac189a1395f7465f1b3755548002ced8c289b7f3eb04c273b7b6548c515R31)