### PR TITLE
feat(CA-477): fully automated linter rule creation via Cursor Rule

### DIFF
--- a/.cursor/rules/create-linter-rule.mdc
+++ b/.cursor/rules/create-linter-rule.mdc
@@ -18,6 +18,8 @@ The user will provide a rule spec — either a path to a `.md` or `.txt` file (e
 - `## Bad` — Dart code block(s) that should trigger the rule
 - `## Good` — Dart code block(s) showing correct code
 
+**Spec file is input only.** Do not stage or commit it. `scripts/create_linter_rule_from_spec.sh` stages only generated artifacts (analyzer, rule, registration, tests, example, docs). Do not create or copy the spec into `rule_specs/` as part of rule generation unless the user explicitly asks you to save it for their own workflow.
+
 ## Steps
 
 ### 0. Validate the spec

--- a/.cursor/rules/create-linter-rule.mdc
+++ b/.cursor/rules/create-linter-rule.mdc
@@ -1,0 +1,99 @@
+---
+description: Creates a new custom linter rule from a spec file. Use this rule whenever the user asks to create, add, or implement a new linter rule, references a rule spec file, or asks to automate linter rule creation.
+alwaysApply: false
+---
+
+# Create a Custom Linter Rule from a Spec
+
+When the user asks you to create a new custom linter rule, follow these steps in order. You have full terminal access — run the shell script yourself at the end. Do not ask the user to run anything.
+
+## Input
+
+The user will provide a rule spec — either a path to a `.md` or `.txt` file (e.g. `rule_specs/my_rule.md`) or content pasted directly. The spec format is:
+
+- **First heading**: rule name in `snake_case`, e.g. `# forbid_foo`
+- **Description**: 1–2 sentences after the heading
+- **Optional** `**Scope**`: `test_only` | `include_tests` | (omit = production only)
+- **Optional** `**Exceptions**`: when to skip the rule
+- `## Bad` — Dart code block(s) that should trigger the rule
+- `## Good` — Dart code block(s) showing correct code
+
+## Steps
+
+### 1. Parse the spec
+
+Extract:
+- `rule_name` — from the first `#` heading, normalized to `snake_case`
+- `description` — paragraph after the heading (used in `problemMessage` and doc comments)
+- `scope` — `test_only` → `testOnly: true`; `include_tests` → `includeTests: true`; omit otherwise
+- `exceptions` — used in `shouldSkipFile` or visitor logic
+- `bad_examples` / `good_examples` — drive the analyzer implementation and tests
+
+### 2. Create the analyzer
+
+**File:** `lib/core/analyzers/<rule_name>_analyzer.dart`
+
+- Extend `BaseAnalyzer`
+- Implement `ruleName`, `problemMessage`, `correctionMessage`
+- Implement `analyze(CompilationUnit)` using a `RecursiveAstVisitor` to detect nodes matching the Bad examples
+- Call `createIssue(node)` for each violation
+- If exceptions were specified, implement `shouldSkipFile(String path)`
+
+Reference: `lib/core/analyzers/forbid_datetime_now_analyzer.dart`
+
+### 3. Create the rule class
+
+**File:** `lib/custom_lint_rules/<rule_name>.dart`
+
+- Extend `BaseLintRule`
+- Constructor: `super(BaseLintRule.createLintCode(_analyzer), testOnly: ...)` — include `testOnly: true` or `includeTests: true` based on scope; omit both if scope is default
+- `static final _analyzer = <PascalCaseRuleName>Analyzer();`
+- `@override BaseAnalyzer get analyzer => _analyzer;`
+- Add doc comment from the spec description
+
+Reference: `lib/custom_lint_rules/forbid_datetime_now.dart`
+
+### 4. Register the rule
+
+**File:** `lib/ripplearc_linter.dart`
+
+- Add `import 'custom_lint_rules/<rule_name>.dart';`
+- In `getLintRules(...)`, add `<PascalCaseRuleClass>()` to the returned list
+
+### 5. Add tests (required)
+
+**File:** `test/custom_lint_rules/<rule_name>_test.dart`
+
+- Use `parseString`, `TestCustomLintResolver`, `TestErrorReporter`, `TestCustomLintContext`
+- At minimum: one test that expects a violation (Bad example) and one that expects no violation (Good example)
+
+Reference: `test/custom_lint_rules/forbid_datetime_now_test.dart`
+
+### 6. Add example and docs (optional)
+
+- `example/example_<rule_name>_rule.dart` — Bad/Good code with `// LINT` and `// OK` comments
+- `docs/<rule_name>.md` — same structure as `docs/forbid_datetime_now.md`
+
+### 7. Run the shell script to create the branch and PR
+
+Once all files are created and saved, run the script yourself from the terminal:
+
+```bash
+./scripts/create_linter_rule_from_spec.sh <rule_name> [base_branch]
+```
+
+Example:
+
+```bash
+./scripts/create_linter_rule_from_spec.sh forbid_foo
+```
+
+The script will:
+1. Normalize the rule name to `snake_case`
+2. Create branch `rule/<rule_name>`
+3. Stage only the rule-related files
+4. Commit with message `Add <rule_name> linter rule`
+5. Push the branch
+6. Create the PR via `gh` CLI (or print the compare URL if `gh` is unavailable)
+
+Do not ask the user to run this — run it yourself.

--- a/.cursor/rules/create-linter-rule.mdc
+++ b/.cursor/rules/create-linter-rule.mdc
@@ -69,7 +69,7 @@ Reference: `lib/custom_lint_rules/forbid_datetime_now.dart`
 
 Reference: `test/custom_lint_rules/forbid_datetime_now_test.dart`
 
-### 6. Add example and docs (optional)
+### 6. Add example and docs (required)
 
 - `example/example_<rule_name>_rule.dart` — Bad/Good code with `// LINT` and `// OK` comments
 - `docs/<rule_name>.md` — same structure as `docs/forbid_datetime_now.md`

--- a/.cursor/rules/create-linter-rule.mdc
+++ b/.cursor/rules/create-linter-rule.mdc
@@ -20,6 +20,16 @@ The user will provide a rule spec — either a path to a `.md` or `.txt` file (e
 
 ## Steps
 
+### 0. Validate the spec
+
+Before generating any files, confirm the spec contains:
+
+- A `#` heading with a `snake_case` rule name
+- At least one `## Bad` Dart code block showing a concrete violation
+- At least one `## Good` Dart code block showing compliant code
+
+If any of these are missing, stop and ask the user to complete the spec. Do not proceed with an incomplete spec.
+
 ### 1. Parse the spec
 
 Extract:
@@ -33,6 +43,7 @@ Extract:
 
 **File:** `lib/core/analyzers/<rule_name>_analyzer.dart`
 
+- Before writing the analyzer, state which AST node type the visitor will target (e.g. `MethodInvocation`, `InstanceCreationExpression`, `PrefixedIdentifier`). If the Bad example is ambiguous about the node to visit, ask the user to clarify before generating code.
 - Extend `BaseAnalyzer`
 - Implement `ruleName`, `problemMessage`, `correctionMessage`
 - Implement `analyze(CompilationUnit)` using a `RecursiveAstVisitor` to detect nodes matching the Bad examples
@@ -92,8 +103,9 @@ The script will:
 1. Normalize the rule name to `snake_case`
 2. Create branch `rule/<rule_name>`
 3. Stage only the rule-related files
-4. Commit with message `Add <rule_name> linter rule`
-5. Push the branch
-6. Create the PR via `gh` CLI (or print the compare URL if `gh` is unavailable)
+4. Run `dart analyze lib/ test/` and `dart test test/custom_lint_rules/<rule_name>_test.dart` (fails before commit if either fails)
+5. Commit with message `Add <rule_name> linter rule`
+6. Push the branch
+7. Create the PR via `gh` CLI (or print the compare URL if `gh` is unavailable)
 
 Do not ask the user to run this — run it yourself.

--- a/docs/wiki-create-custom-linter-rule-with-agent.md
+++ b/docs/wiki-create-custom-linter-rule-with-agent.md
@@ -114,7 +114,7 @@ The PR is opened automatically.
 
 ## 4. Where things live
 
-- **Rule spec**: `rule_specs/<rule_name>.md` (recommended) or any path you reference.
+- **Rule spec**: `rule_specs/<rule_name>.md` (recommended) or any path you reference — **your input only**; the automation script does not stage or commit spec files, only generated linter files.
 - **Agent instructions**: `.cursor/rules/create-linter-rule.mdc`
 - **Git/PR automation**: `scripts/create_linter_rule_from_spec.sh`
 - **Generated files**:

--- a/docs/wiki-create-custom-linter-rule-with-agent.md
+++ b/docs/wiki-create-custom-linter-rule-with-agent.md
@@ -87,13 +87,15 @@ Or paste the spec inline:
 
 The agent will:
 
-1. Parse the spec (rule name, description, scope, exceptions, Bad/Good examples).
-2. Create `lib/core/analyzers/<rule_name>_analyzer.dart`.
-3. Create `lib/custom_lint_rules/<rule_name>.dart`.
-4. Update `lib/ripplearc_linter.dart`.
-5. Create `test/custom_lint_rules/<rule_name>_test.dart`.
-6. Add `example/` and `docs/` files.
-7. Run `./scripts/create_linter_rule_from_spec.sh <rule_name>` itself — no input from you.
+1. Validate the spec: `#` heading in `snake_case`, at least one `## Bad` and one `## Good` Dart code block; if anything is missing, ask you to complete the spec before continuing.
+2. Parse the spec (rule name, description, scope, exceptions, Bad/Good examples).
+3. Decide which AST node type the visitor will target (e.g. `MethodInvocation`); if the Bad example is ambiguous, ask you to clarify before writing the analyzer.
+4. Create `lib/core/analyzers/<rule_name>_analyzer.dart`.
+5. Create `lib/custom_lint_rules/<rule_name>.dart`.
+6. Update `lib/ripplearc_linter.dart`.
+7. Create `test/custom_lint_rules/<rule_name>_test.dart`.
+8. Add `example/` and `docs/` files (required).
+9. Run `./scripts/create_linter_rule_from_spec.sh <rule_name>` itself — no input from you. The script runs `dart analyze lib/ test/` and `dart test test/custom_lint_rules/<rule_name>_test.dart` before committing.
 
 The PR is opened automatically.
 
@@ -106,7 +108,7 @@ The PR is opened automatically.
 | 1 | You | Write or paste the rule spec. |
 | 2 | You | Ask the Cursor agent to create the rule. |
 | 3 | Agent | Generates all Dart files. |
-| 4 | Agent | Runs `create_linter_rule_from_spec.sh` — creates branch, commits, pushes, opens PR. |
+| 4 | Agent | Runs `create_linter_rule_from_spec.sh` — creates branch, runs `dart analyze` / rule tests, commits, pushes, opens PR. |
 
 ---
 
@@ -131,6 +133,7 @@ The PR is opened automatically.
 - **PR not created** — install and authenticate GitHub CLI: `gh auth login`.
 - **Rule name with hyphens** — the script normalises `forbid-foo` → `forbid_foo` correctly.
 - **Tests or analyzer don't match spec** — refine the Bad/Good examples and ask the agent to update accordingly.
+- **Script exits before commit** — `scripts/create_linter_rule_from_spec.sh` runs `dart analyze lib/ test/` and `dart test test/custom_lint_rules/<rule_name>_test.dart` before committing. Fix the reported issues, then rerun the script (or have the agent rerun it).
 
 ---
 

--- a/docs/wiki-create-custom-linter-rule-with-agent.md
+++ b/docs/wiki-create-custom-linter-rule-with-agent.md
@@ -1,0 +1,141 @@
+# Wiki: Create a Custom Linter Rule Using the Cursor Agent
+
+This guide explains how to add a new custom linter rule fully automatically using the Cursor agent. You provide a rule spec — the agent generates all required Dart files, runs the git workflow, and opens the PR. No manual steps required.
+
+---
+
+## How it works
+
+Two files drive the automation:
+
+| File | Role |
+|------|------|
+| `.cursor/rules/create-linter-rule.mdc` | Agent instructions — tells Cursor exactly what Dart files to generate and how |
+| `scripts/create_linter_rule_from_spec.sh` | Git/PR automation — creates the branch, stages files, commits, pushes, and opens the PR |
+
+The agent reads the Cursor Rule, generates the files, then runs the shell script itself. You don't touch the script.
+
+---
+
+## Prerequisites
+
+- **Cursor** with agent/composer available and the `ripplearc-flutter-lint` repo open.
+- **Git** installed and authenticated.
+- **GitHub CLI** (`gh`) installed and authenticated — for automatic PR creation. If absent, the script prints a browser URL as fallback.
+
+---
+
+## 1. Rule spec format
+
+Write a spec in Markdown (`.md`) describing what the rule enforces.
+
+### Required
+
+- **Rule name**: first heading, `snake_case`. Example: `# forbid_foo`
+- **Description**: 1–2 sentences after the heading.
+- **Bad**: a `## Bad` section with a Dart code block showing code that should be reported.
+- **Good**: a `## Good` section with a Dart code block showing allowed code.
+
+### Optional
+
+- **Scope**: `**Scope**: include_tests` or `**Scope**: test_only`.
+  - `test_only` → rule runs only in test files.
+  - `include_tests` → rule runs in both lib and test.
+  - Omit → rule runs only in production (lib) code.
+- **Exceptions**: when to skip (e.g. "Skip in files ending with `_impl.dart`").
+
+### Example spec
+
+Save as `rule_specs/forbid_foo.md`:
+
+~~~markdown
+# forbid_foo
+
+Short description: do not use Foo.bar() in production; use Baz.bar() instead for testability.
+
+**Scope**: include_tests
+**Exceptions**: Skip in `foo_impl.dart`
+
+## Bad
+
+```dart
+void doSomething() {
+  Foo.bar();  // should be reported
+}
+```
+
+## Good
+
+```dart
+void doSomething(Baz baz) {
+  baz.bar();  // OK
+}
+```
+~~~
+
+---
+
+## 2. How to use the agent
+
+Open Cursor's Composer (Agent mode) and say:
+
+> Create a new linter rule from `rule_specs/forbid_foo.md`.
+
+Or paste the spec inline:
+
+> Create a new linter rule from this spec: [paste spec content]
+
+The agent will:
+
+1. Parse the spec (rule name, description, scope, exceptions, Bad/Good examples).
+2. Create `lib/core/analyzers/<rule_name>_analyzer.dart`.
+3. Create `lib/custom_lint_rules/<rule_name>.dart`.
+4. Update `lib/ripplearc_linter.dart`.
+5. Create `test/custom_lint_rules/<rule_name>_test.dart`.
+6. Optionally add `example/` and `docs/` files.
+7. Run `./scripts/create_linter_rule_from_spec.sh <rule_name>` itself — no input from you.
+
+The PR is opened automatically.
+
+---
+
+## 3. Quick reference
+
+| Step | Who | Action |
+|------|-----|--------|
+| 1 | You | Write or paste the rule spec. |
+| 2 | You | Ask the Cursor agent to create the rule. |
+| 3 | Agent | Generates all Dart files. |
+| 4 | Agent | Runs `create_linter_rule_from_spec.sh` — creates branch, commits, pushes, opens PR. |
+
+---
+
+## 4. Where things live
+
+- **Rule spec**: `rule_specs/<rule_name>.md` (recommended) or any path you reference.
+- **Agent instructions**: `.cursor/rules/create-linter-rule.mdc`
+- **Git/PR automation**: `scripts/create_linter_rule_from_spec.sh`
+- **Generated files**:
+  - `lib/core/analyzers/<rule_name>_analyzer.dart`
+  - `lib/custom_lint_rules/<rule_name>.dart`
+  - `lib/ripplearc_linter.dart` (updated)
+  - `test/custom_lint_rules/<rule_name>_test.dart`
+  - Optionally: `example/`, `docs/<rule_name>.md`
+
+---
+
+## 5. Troubleshooting
+
+- **Agent didn't register the rule** — remind it to add the import and rule instance in `lib/ripplearc_linter.dart`.
+- **Script says "no rule files staged"** — the agent may not have saved files to disk. Ask it to write the files and retry.
+- **PR not created** — install and authenticate GitHub CLI: `gh auth login`.
+- **Rule name with hyphens** — the script normalises `forbid-foo` → `forbid_foo` correctly.
+- **Tests or analyzer don't match spec** — refine the Bad/Good examples and ask the agent to update accordingly.
+
+---
+
+## 6. Summary
+
+1. Write a rule spec (`rule_specs/<rule_name>.md`).
+2. Ask the Cursor agent: *"Create a new linter rule from `rule_specs/<rule_name>.md`"*.
+3. The agent generates the files and opens the PR automatically — nothing else needed.

--- a/docs/wiki-create-custom-linter-rule-with-agent.md
+++ b/docs/wiki-create-custom-linter-rule-with-agent.md
@@ -92,7 +92,7 @@ The agent will:
 3. Create `lib/custom_lint_rules/<rule_name>.dart`.
 4. Update `lib/ripplearc_linter.dart`.
 5. Create `test/custom_lint_rules/<rule_name>_test.dart`.
-6. Optionally add `example/` and `docs/` files.
+6. Add `example/` and `docs/` files.
 7. Run `./scripts/create_linter_rule_from_spec.sh <rule_name>` itself — no input from you.
 
 The PR is opened automatically.
@@ -120,7 +120,7 @@ The PR is opened automatically.
   - `lib/custom_lint_rules/<rule_name>.dart`
   - `lib/ripplearc_linter.dart` (updated)
   - `test/custom_lint_rules/<rule_name>_test.dart`
-  - Optionally: `example/`, `docs/<rule_name>.md`
+  - `example/`, `docs/<rule_name>.md`
 
 ---
 

--- a/scripts/create_linter_rule_from_spec.sh
+++ b/scripts/create_linter_rule_from_spec.sh
@@ -131,6 +131,22 @@ if [ -z "$(git diff --cached --name-only)" ]; then
   exit 1
 fi
 
+# ---------------------------------------------------------------------------
+# Validate before committing
+# ---------------------------------------------------------------------------
+
+echo "Running dart analyze..."
+if ! dart analyze lib/ test/; then
+  echo "Error: dart analyze failed. Fix the issues above before committing."
+  exit 1
+fi
+
+echo "Running dart test..."
+if ! dart test "test/custom_lint_rules/${RULE_NAME}_test.dart"; then
+  echo "Error: dart test failed. Fix the failures above before committing."
+  exit 1
+fi
+
 git commit -m "Add ${RULE_NAME} linter rule"
 
 echo "Pushing branch $BRANCH_NAME..."

--- a/scripts/create_linter_rule_from_spec.sh
+++ b/scripts/create_linter_rule_from_spec.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+#
+# create_linter_rule_from_spec.sh
+#
+# Purpose:
+#   Git/PR automation for new linter rules. Creates the branch, stages rule files,
+#   commits, pushes, and opens a PR.
+#
+#   Agent instructions for generating the rule files live in:
+#     .cursor/rules/create-linter-rule.mdc
+#
+# Usage:
+#   ./scripts/create_linter_rule_from_spec.sh <rule_name> [base_branch]
+#
+# Arguments:
+#   rule_name   (required) snake_case name of the rule, e.g. forbid_datetime_now
+#   base_branch (optional) branch to open PR against. Default: main
+#
+# Requirements:
+#   - Git repository with the new rule files already present (agent has created them).
+#   - For PR creation: gh (GitHub CLI) installed and authenticated.
+#
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_open_pr_in_browser() {
+  local base="$1" head="$2" origin_url pr_url
+  origin_url=$(git remote get-url origin 2>/dev/null | sed 's/\.git$//')
+  [ -z "$origin_url" ] && return 1
+  pr_url="${origin_url}/compare/${base}...${head}"
+  echo "Open in browser to create the PR: $pr_url"
+  if command -v xdg-open >/dev/null 2>&1; then xdg-open "$pr_url" 2>/dev/null && return 0; fi
+  if command -v open      >/dev/null 2>&1; then open      "$pr_url" 2>/dev/null && return 0; fi
+  if command -v start     >/dev/null 2>&1; then start     "$pr_url" 2>/dev/null && return 0; fi
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Arguments
+# ---------------------------------------------------------------------------
+
+RULE_NAME="${1:-}"
+BASE_BRANCH="${2:-main}"
+
+if [ -z "$RULE_NAME" ]; then
+  echo "Usage: $0 <rule_name> [base_branch]"
+  echo "Example: $0 forbid_foo main"
+  echo ""
+  echo "Rule name must be snake_case (e.g. forbid_datetime_now)."
+  echo "Run this script after the Cursor agent has generated the rule files."
+  exit 1
+fi
+
+# Normalize to snake_case: lowercase, spaces→underscore, hyphens→underscore
+RULE_NAME=$(echo "$RULE_NAME" | tr '[:upper:]' '[:lower:]' | tr -s ' ' '_' | tr '-' '_')
+BRANCH_NAME="rule/${RULE_NAME}"
+
+# ---------------------------------------------------------------------------
+# Repo root
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# ---------------------------------------------------------------------------
+# Already on rule branch and clean → just push + create PR
+# ---------------------------------------------------------------------------
+
+if [ -z "$(git status --porcelain)" ]; then
+  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  if [ "$CURRENT_BRANCH" = "$BRANCH_NAME" ]; then
+    git push -u origin "$BRANCH_NAME" 2>/dev/null || true
+    if command -v gh >/dev/null 2>&1; then
+      if gh pr view --head "$BRANCH_NAME" >/dev/null 2>&1; then
+        echo "A PR for branch $BRANCH_NAME already exists."
+        gh pr view --web 2>/dev/null || true
+      else
+        gh pr create --base "$BASE_BRANCH" --head "$BRANCH_NAME" \
+          --title "Add ${RULE_NAME} linter rule" \
+          --body "Adds the \`${RULE_NAME}\` custom linter rule.
+
+- Analyzer: \`lib/core/analyzers/${RULE_NAME}_analyzer.dart\`
+- Rule: \`lib/custom_lint_rules/${RULE_NAME}.dart\`
+- Registered in \`lib/ripplearc_linter.dart\`
+
+Created via Cursor agent + \`scripts/create_linter_rule_from_spec.sh\`."
+      fi
+    else
+      _open_pr_in_browser "$BASE_BRANCH" "$BRANCH_NAME" \
+        || echo "  Open: $(git remote get-url origin | sed 's/\.git$//')/compare/${BASE_BRANCH}...${BRANCH_NAME}"
+    fi
+    exit 0
+  fi
+  echo "Error: no changes to commit and not on branch $BRANCH_NAME."
+  echo "Expected rule files:"
+  echo "  lib/core/analyzers/${RULE_NAME}_analyzer.dart"
+  echo "  lib/custom_lint_rules/${RULE_NAME}.dart"
+  echo "  lib/ripplearc_linter.dart (updated)"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Create branch, stage, commit, push, open PR
+# ---------------------------------------------------------------------------
+
+if git rev-parse --verify "$BRANCH_NAME" >/dev/null 2>&1; then
+  git checkout "$BRANCH_NAME"
+else
+  git checkout -b "$BRANCH_NAME"
+fi
+
+# Stage only the files this rule touches
+for f in \
+  "lib/core/analyzers/${RULE_NAME}_analyzer.dart" \
+  "lib/custom_lint_rules/${RULE_NAME}.dart" \
+  "lib/ripplearc_linter.dart" \
+  "test/custom_lint_rules/${RULE_NAME}_test.dart" \
+  "example/example_${RULE_NAME}_rule.dart" \
+  "docs/${RULE_NAME}.md" \
+  "rule_specs/${RULE_NAME}.md"; do
+  [ -f "$f" ] && git add "$f"
+done
+
+if [ -z "$(git diff --cached --name-only)" ]; then
+  echo "Error: no rule files staged. Check that the agent created the expected files."
+  exit 1
+fi
+
+git commit -m "Add ${RULE_NAME} linter rule"
+
+echo "Pushing branch $BRANCH_NAME..."
+git push -u origin "$BRANCH_NAME"
+
+if command -v gh >/dev/null 2>&1; then
+  gh pr create --base "$BASE_BRANCH" --head "$BRANCH_NAME" \
+    --title "Add ${RULE_NAME} linter rule" \
+    --body "Adds the \`${RULE_NAME}\` custom linter rule.
+
+- Analyzer: \`lib/core/analyzers/${RULE_NAME}_analyzer.dart\`
+- Rule: \`lib/custom_lint_rules/${RULE_NAME}.dart\`
+- Registered in \`lib/ripplearc_linter.dart\`
+
+Created via Cursor agent + \`scripts/create_linter_rule_from_spec.sh\`."
+else
+  _open_pr_in_browser "$BASE_BRANCH" "$BRANCH_NAME" \
+    || echo "  Open: $(git remote get-url origin | sed 's/\.git$//')/compare/${BASE_BRANCH}...${BRANCH_NAME}"
+fi
+
+echo "Done."

--- a/scripts/create_linter_rule_from_spec.sh
+++ b/scripts/create_linter_rule_from_spec.sh
@@ -58,6 +58,14 @@ fi
 RULE_NAME=$(echo "$RULE_NAME" | tr '[:upper:]' '[:lower:]' | tr -s ' ' '_' | tr '-' '_')
 BRANCH_NAME="rule/${RULE_NAME}"
 
+PR_BODY="Adds the \`${RULE_NAME}\` custom linter rule.
+
+- Analyzer: \`lib/core/analyzers/${RULE_NAME}_analyzer.dart\`
+- Rule: \`lib/custom_lint_rules/${RULE_NAME}.dart\`
+- Registered in \`lib/ripplearc_linter.dart\`
+
+Created via Cursor agent + \`scripts/create_linter_rule_from_spec.sh\`."
+
 # ---------------------------------------------------------------------------
 # Repo root
 # ---------------------------------------------------------------------------
@@ -73,7 +81,7 @@ cd "$REPO_ROOT"
 if [ -z "$(git status --porcelain)" ]; then
   CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
   if [ "$CURRENT_BRANCH" = "$BRANCH_NAME" ]; then
-    git push -u origin "$BRANCH_NAME" 2>/dev/null || true
+    git push -u origin "$BRANCH_NAME"
     if command -v gh >/dev/null 2>&1; then
       if gh pr view --head "$BRANCH_NAME" >/dev/null 2>&1; then
         echo "A PR for branch $BRANCH_NAME already exists."
@@ -81,17 +89,10 @@ if [ -z "$(git status --porcelain)" ]; then
       else
         gh pr create --base "$BASE_BRANCH" --head "$BRANCH_NAME" \
           --title "Add ${RULE_NAME} linter rule" \
-          --body "Adds the \`${RULE_NAME}\` custom linter rule.
-
-- Analyzer: \`lib/core/analyzers/${RULE_NAME}_analyzer.dart\`
-- Rule: \`lib/custom_lint_rules/${RULE_NAME}.dart\`
-- Registered in \`lib/ripplearc_linter.dart\`
-
-Created via Cursor agent + \`scripts/create_linter_rule_from_spec.sh\`."
+          --body "$PR_BODY"
       fi
     else
-      _open_pr_in_browser "$BASE_BRANCH" "$BRANCH_NAME" \
-        || echo "  Open: $(git remote get-url origin | sed 's/\.git$//')/compare/${BASE_BRANCH}...${BRANCH_NAME}"
+      _open_pr_in_browser "$BASE_BRANCH" "$BRANCH_NAME" || true
     fi
     exit 0
   fi
@@ -138,16 +139,9 @@ git push -u origin "$BRANCH_NAME"
 if command -v gh >/dev/null 2>&1; then
   gh pr create --base "$BASE_BRANCH" --head "$BRANCH_NAME" \
     --title "Add ${RULE_NAME} linter rule" \
-    --body "Adds the \`${RULE_NAME}\` custom linter rule.
-
-- Analyzer: \`lib/core/analyzers/${RULE_NAME}_analyzer.dart\`
-- Rule: \`lib/custom_lint_rules/${RULE_NAME}.dart\`
-- Registered in \`lib/ripplearc_linter.dart\`
-
-Created via Cursor agent + \`scripts/create_linter_rule_from_spec.sh\`."
+    --body "$PR_BODY"
 else
-  _open_pr_in_browser "$BASE_BRANCH" "$BRANCH_NAME" \
-    || echo "  Open: $(git remote get-url origin | sed 's/\.git$//')/compare/${BASE_BRANCH}...${BRANCH_NAME}"
+  _open_pr_in_browser "$BASE_BRANCH" "$BRANCH_NAME" || true
 fi
 
 echo "Done."

--- a/scripts/create_linter_rule_from_spec.sh
+++ b/scripts/create_linter_rule_from_spec.sh
@@ -114,15 +114,14 @@ else
   git checkout -b "$BRANCH_NAME"
 fi
 
-# Stage only the files this rule touches
+# Stage only generated rule artifacts (not rule_specs/*.md — spec is user input, not committed)
 for f in \
   "lib/core/analyzers/${RULE_NAME}_analyzer.dart" \
   "lib/custom_lint_rules/${RULE_NAME}.dart" \
   "lib/ripplearc_linter.dart" \
   "test/custom_lint_rules/${RULE_NAME}_test.dart" \
   "example/example_${RULE_NAME}_rule.dart" \
-  "docs/${RULE_NAME}.md" \
-  "rule_specs/${RULE_NAME}.md"; do
+  "docs/${RULE_NAME}.md"; do
   [ -f "$f" ] && git add "$f"
 done
 

--- a/test/custom_lint_rules/test_file_mutation_coverage_test.dart
+++ b/test/custom_lint_rules/test_file_mutation_coverage_test.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:io' as io;
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:ripplearc_linter/custom_lint_rules/test_file_mutation_coverage.dart';

--- a/test/standalone_checker_test.dart
+++ b/test/standalone_checker_test.dart
@@ -377,7 +377,7 @@ void main() {
           );
 
           final checker = StandaloneLintChecker();
-          final issues = await checker.check(
+          await checker.check(
             [testFile.path],
             enabledRules: ['test_file_mutation_coverage'],
           );


### PR DESCRIPTION
## What this does

Replaces the hybrid human+agent workflow in #52 with a fully automated one. You give the Cursor agent a rule spec — it generates all Dart files and opens the PR itself. No manual steps.

## Problem with the approach in #52

The shell script served two purposes in one file:
- An embedded `AGENT INSTRUCTIONS` comment block the agent reads as a prompt
- Bash code the **human** had to run manually after the agent finished

This meant the human was always in the loop to run `./scripts/create_linter_rule_from_spec.sh`.

## New architecture

| File | Role |
|------|------|
| `.cursor/rules/create-linter-rule.mdc` | Agent instructions (separated out) |
| `scripts/create_linter_rule_from_spec.sh` | Git/PR automation only |

The Cursor agent reads the Rule file, generates the Dart files, then **runs the shell script itself** via the terminal. No human steps.

```
Before:  You write spec → Agent generates files → ❌ You run script → PR created
After:   You write spec → Agent generates files + runs script → ✅ PR created
```

## Changes

- **New**: `.cursor/rules/create-linter-rule.mdc` — Cursor Rule with full agent instructions
- **Refactored**: `scripts/create_linter_rule_from_spec.sh` — stripped to git/PR automation only; also fixes:
  - `set -euo pipefail` at top (was missing `pipefail` and `set -e` was mid-file)
  - Hyphen normalization bug: `tr -d '-'` → `tr '-' '_'` (`forbid-foo` now correctly becomes `forbid_foo`)
  - Removed interactive `read -p` confirmation prompt (was blocking in non-interactive shells)
  - Replaced broad `git add -A lib/` with explicit per-file staging
- **Updated**: `docs/wiki-create-custom-linter-rule-with-agent.md` — reflects new two-file architecture
