### PR TITLE
feat(linter): add AppRouter and UI exceptions to forbid_modular_get_outside_module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.1 - forbid_modular_get_outside_module Exceptions (patch)
+
+### Improvements
+
+- **`forbid_modular_get_outside_module`**: Added a built-in exception for `Modular.get<AppRouter>()` so global navigation access remains available without weakening the rest of the rule.
+- **`forbid_modular_get_outside_module`**: Added presentation-layer exemptions for classes extending `StatelessWidget`, `StatefulWidget`, or `*Page`.
+- **`forbid_modular_get_outside_module`**: Added optional `allow_list` support in `analysis_options.yaml` for additional approved global services.
+
 ## 0.4.0 - Forbid Modular.get Outside Module (minor)
 
 ### New Rule

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
 # Changelog
 
-## 0.4.1 - forbid_modular_get_outside_module Exceptions (patch)
+## 0.4.1 - forbid_modular_get_outside_module allow_list support (patch)
 
 ### Improvements
 
-- **`forbid_modular_get_outside_module`**: Added a built-in exception for `Modular.get<AppRouter>()` so global navigation access remains available without weakening the rest of the rule.
-- **`forbid_modular_get_outside_module`**: Added presentation-layer exemptions for classes extending `StatelessWidget`, `StatefulWidget`, or `*Page`.
-- **`forbid_modular_get_outside_module`**: Added optional `allow_list` support in `analysis_options.yaml` for additional approved global services.
+- **`forbid_modular_get_outside_module`**: Added optional `allow_list` support in `analysis_options.yaml` for project-specific global types that are allowed to be fetched with `Modular.get<T>()` outside module files. No types are exempt by default; all exceptions must be declared explicitly.
 
 ## 0.4.0 - Forbid Modular.get Outside Module (minor)
 

--- a/docs/forbid_modular_get_outside_module.md
+++ b/docs/forbid_modular_get_outside_module.md
@@ -13,8 +13,7 @@ custom_lint:
   rules:
     forbid_modular_get_outside_module:
       allow_list:
-        - AppRouter
-        - GlobalAnalytics
+        - GlobalCrashReporter
 ```
 
 ## Bad
@@ -54,12 +53,12 @@ class AppCoreModule extends Module {
 ```
 
 ```dart
-class AppRouter {}
+class GlobalCrashReporter {}
 
-class AnalyticsConsumer {
-  void track() {
-    // OK — AppRouter declared in allow_list in analysis_options.yaml
-    final router = Modular.get<AppRouter>();
+class CrashReportingBootstrapper {
+  void init() {
+    // OK — GlobalCrashReporter declared in allow_list in analysis_options.yaml
+    final reporter = Modular.get<GlobalCrashReporter>();
   }
 }
 ```

--- a/docs/forbid_modular_get_outside_module.md
+++ b/docs/forbid_modular_get_outside_module.md
@@ -5,6 +5,21 @@
 
 This rule specifically ignores files inside the `test/` directory as well as generated files like `*.g.dart` or `*.freezed.dart`.
 
+It also supports narrow presentation and global exceptions:
+- `Modular.get<AppRouter>()` is always allowed.
+- `Modular.get<T>()` is allowed inside classes extending `StatelessWidget`, `StatefulWidget`, or classes named/extending `*Page`.
+
+For project-specific global services, extend the exception list in `analysis_options.yaml`:
+
+```yaml
+custom_lint:
+  rules:
+    forbid_modular_get_outside_module:
+      allow_list:
+        - AppRouter
+        - GlobalAnalytics
+```
+
 ## Bad
 ```dart
 // Normal production file (not _module.dart)
@@ -37,6 +52,16 @@ class AppCoreModule extends Module {
     i.addFactory<UserService>(
       () => UserService(Modular.get<HttpClient>(), Modular.get<UserRepository>()) // OK
     );
+  }
+}
+```
+
+```dart
+class AppRouter {}
+
+class CheckoutPage extends StatelessWidget {
+  void openCheckout() {
+    final router = Modular.get<AppRouter>(); // OK
   }
 }
 ```

--- a/docs/forbid_modular_get_outside_module.md
+++ b/docs/forbid_modular_get_outside_module.md
@@ -4,10 +4,7 @@
 `Modular.get<T>()` is only allowed in module files (`*_module.dart`). This rule prevents developers from making arbitrary dependencies retrievals inline elsewhere in the application, promoting proper constructor-based dependency injection.
 
 This rule specifically ignores files inside the `test/` directory as well as generated files like `*.g.dart` or `*.freezed.dart`.
-
-It also supports narrow presentation and global exceptions:
-- `Modular.get<AppRouter>()` is always allowed.
-- `Modular.get<T>()` is allowed inside classes extending `StatelessWidget`, `StatefulWidget`, or classes named/extending `*Page`.
+All non-module usages are flagged unless the requested type is explicitly listed in `allow_list`.
 
 For project-specific global services, extend the exception list in `analysis_options.yaml`:
 
@@ -61,7 +58,7 @@ class AppRouter {}
 
 class CheckoutPage extends StatelessWidget {
   void openCheckout() {
-    final router = Modular.get<AppRouter>(); // OK
+    final router = Modular.get<AppRouter>(); // OK (because AppRouter is in allow_list)
   }
 }
 ```

--- a/docs/forbid_modular_get_outside_module.md
+++ b/docs/forbid_modular_get_outside_module.md
@@ -56,9 +56,10 @@ class AppCoreModule extends Module {
 ```dart
 class AppRouter {}
 
-class CheckoutPage extends StatelessWidget {
-  void openCheckout() {
-    final router = Modular.get<AppRouter>(); // OK (because AppRouter is in allow_list)
+class AnalyticsConsumer {
+  void track() {
+    // OK — AppRouter declared in allow_list in analysis_options.yaml
+    final router = Modular.get<AppRouter>();
   }
 }
 ```

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -3,3 +3,9 @@ include: package:flutter_lints/flutter.yaml
 analyzer:
   plugins:
     - custom_lint
+
+custom_lint:
+  rules:
+    forbid_modular_get_outside_module:
+      allow_list:
+        - AppRouter

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -8,4 +8,4 @@ custom_lint:
   rules:
     forbid_modular_get_outside_module:
       allow_list:
-        - AppRouter
+        - GlobalCrashReporter

--- a/example/core_module.dart
+++ b/example/core_module.dart
@@ -5,8 +5,7 @@ class CoreModule extends Module {
   void binds(Injector i) {
     i.addFactory<ServiceClass>(() {
       // OK — this file ends in _module.dart
-      final okFoo = Modular.get<Foo>();
-      okFoo.hashCode;
+      Modular.get<Foo>();
       return ServiceClass();
     });
   }

--- a/example/core_module.dart
+++ b/example/core_module.dart
@@ -1,0 +1,13 @@
+import 'example_forbid_modular_get_outside_module_rule.dart';
+
+class CoreModule extends Module {
+  @override
+  void binds(Injector i) {
+    i.addFactory<ServiceClass>(() {
+      // OK — this file ends in _module.dart
+      final okFoo = Modular.get<Foo>();
+      okFoo.hashCode;
+      return ServiceClass();
+    });
+  }
+}

--- a/example/example_forbid_modular_get_outside_module_rule.dart
+++ b/example/example_forbid_modular_get_outside_module_rule.dart
@@ -3,14 +3,20 @@
 class Modular {
   static T get<T>() => throw UnimplementedError();
 }
+
 class Module {
   void binds(Injector i) {}
 }
+
 class Injector {
   void addFactory<T>(T Function() f) {}
 }
 
 class Foo {}
+
+class AppRouter {}
+
+class StatelessWidget {}
 
 // Normal production code
 class ServiceClass {
@@ -24,6 +30,13 @@ class FakeService {
   void mock() {
     // LINT
     final mockFoo = Modular.get<Foo>();
+  }
+}
+
+class CheckoutPage extends StatelessWidget {
+  void openCheckout() {
+    // OK
+    final router = Modular.get<AppRouter>();
   }
 }
 

--- a/example/example_forbid_modular_get_outside_module_rule.dart
+++ b/example/example_forbid_modular_get_outside_module_rule.dart
@@ -14,7 +14,7 @@ class Injector {
 
 class Foo {}
 
-class AppRouter {}
+class GlobalCrashReporter {}
 
 // Normal production code
 class ServiceClass {
@@ -31,10 +31,10 @@ class FakeService {
   }
 }
 
-class AnalyticsConsumer {
-  void track() {
-    // OK — AppRouter declared in allow_list in analysis_options.yaml
-    final router = Modular.get<AppRouter>();
+class CrashReportingBootstrapper {
+  void init() {
+    // OK — GlobalCrashReporter declared in allow_list in analysis_options.yaml
+    final reporter = Modular.get<GlobalCrashReporter>();
   }
 }
 

--- a/example/example_forbid_modular_get_outside_module_rule.dart
+++ b/example/example_forbid_modular_get_outside_module_rule.dart
@@ -16,8 +16,6 @@ class Foo {}
 
 class AppRouter {}
 
-class StatelessWidget {}
-
 // Normal production code
 class ServiceClass {
   void doWork() {
@@ -33,20 +31,10 @@ class FakeService {
   }
 }
 
-class CheckoutPage extends StatelessWidget {
-  void openCheckout() {
-    // OK
+class AnalyticsConsumer {
+  void track() {
+    // OK — AppRouter declared in allow_list in analysis_options.yaml
     final router = Modular.get<AppRouter>();
   }
 }
 
-class CoreModule extends Module {
-  @override
-  void binds(Injector i) {
-    i.addFactory<ServiceClass>(() {
-      // OK
-      final okFoo = Modular.get<Foo>();
-      return ServiceClass();
-    });
-  }
-}

--- a/lib/core/analyzers/forbid_modular_get_outside_module_analyzer.dart
+++ b/lib/core/analyzers/forbid_modular_get_outside_module_analyzer.dart
@@ -2,9 +2,18 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'base_analyzer.dart';
 import '../models/lint_issue.dart';
+import 'forbid_modular_get_outside_module_config.dart';
+import 'forbid_modular_get_outside_module_config_parser.dart';
 
 /// Analyzer that forbids `Modular.get<T>()` outside of module files.
 class ForbidModularGetOutsideModuleAnalyzer extends BaseAnalyzer {
+  ForbidModularGetOutsideModuleAnalyzer({
+    ForbidModularGetOutsideModuleConfig? config,
+  }) : _config = config;
+
+  final ForbidModularGetOutsideModuleConfig? _config;
+  final Map<String, ForbidModularGetOutsideModuleConfig> _configCache = {};
+
   @override
   String get ruleName => 'forbid_modular_get_outside_module';
 
@@ -13,8 +22,7 @@ class ForbidModularGetOutsideModuleAnalyzer extends BaseAnalyzer {
       'Modular.get<T>() is not allowed outside of module files. Inject dependencies through constructors; use Modular.get only in *_module.dart.';
 
   @override
-  String get correctionMessage =>
-      'Pass the dependency into the constructor.';
+  String get correctionMessage => 'Pass the dependency into the constructor.';
 
   @override
   bool shouldSkipFile(String path) {
@@ -34,7 +42,7 @@ class ForbidModularGetOutsideModuleAnalyzer extends BaseAnalyzer {
     if (path == null || shouldSkipFile(path)) {
       return [];
     }
-    return _analyzeInternally(unit);
+    return _analyzeInternally(unit, _resolveConfig(path));
   }
 
   @override
@@ -46,10 +54,23 @@ class ForbidModularGetOutsideModuleAnalyzer extends BaseAnalyzer {
   }
 
   /// Internal implementation of the analysis logic.
-  List<LintIssue> _analyzeInternally(CompilationUnit unit) {
-    final visitor = _ModularGetVisitor(this);
+  List<LintIssue> _analyzeInternally(
+    CompilationUnit unit,
+    ForbidModularGetOutsideModuleConfig config,
+  ) {
+    final visitor = _ModularGetVisitor(this, config);
     unit.accept(visitor);
     return visitor.issues;
+  }
+
+  ForbidModularGetOutsideModuleConfig _resolveConfig(String path) {
+    if (_config != null) return _config;
+
+    final normalizedPath = path.replaceAll('\\', '/');
+    return _configCache.putIfAbsent(
+      normalizedPath,
+      () => ForbidModularGetOutsideModuleConfigParser.loadFromFile(path),
+    );
   }
 }
 
@@ -57,16 +78,24 @@ class ForbidModularGetOutsideModuleAnalyzer extends BaseAnalyzer {
 /// found outside an allowed module file.
 class _ModularGetVisitor extends RecursiveAstVisitor<void> {
   final BaseAnalyzer analyzer;
+  final ForbidModularGetOutsideModuleConfig config;
   final List<LintIssue> issues = [];
 
-  _ModularGetVisitor(this.analyzer);
+  _ModularGetVisitor(this.analyzer, this.config);
 
   @override
   void visitMethodInvocation(MethodInvocation node) {
-    if (_isModularGetCall(node)) {
+    if (_isForbiddenModularGetCall(node)) {
       issues.add(analyzer.createIssue(node));
     }
     super.visitMethodInvocation(node);
+  }
+
+  bool _isForbiddenModularGetCall(MethodInvocation node) {
+    if (!_isModularGetCall(node)) return false;
+    if (_isAllowedType(node)) return false;
+    if (_isInsideAllowedUiClass(node)) return false;
+    return true;
   }
 
   /// Detects `Modular.get<...>()` and `alias.Modular.get<...>()` where Modular is the class name.
@@ -80,5 +109,31 @@ class _ModularGetVisitor extends RecursiveAstVisitor<void> {
       return true;
     }
     return false;
+  }
+
+  bool _isAllowedType(MethodInvocation node) {
+    final typeArguments = node.typeArguments?.arguments;
+    if (typeArguments == null || typeArguments.isEmpty) return false;
+
+    final rawType = typeArguments.first.toSource();
+    final normalizedType = rawType.split('<').first.split('.').last.trim();
+    return config.allowsType(normalizedType);
+  }
+
+  bool _isInsideAllowedUiClass(AstNode node) {
+    final enclosingClass = node.thisOrAncestorOfType<ClassDeclaration>();
+    if (enclosingClass == null) return false;
+
+    final className = enclosingClass.name.lexeme;
+    if (className.endsWith('Page')) return true;
+
+    final superclass =
+        enclosingClass.extendsClause?.superclass.toSource() ?? '';
+    final normalizedSuperclass =
+        superclass.split('<').first.split('.').last.trim();
+
+    return normalizedSuperclass == 'StatelessWidget' ||
+        normalizedSuperclass == 'StatefulWidget' ||
+        normalizedSuperclass.endsWith('Page');
   }
 }

--- a/lib/core/analyzers/forbid_modular_get_outside_module_analyzer.dart
+++ b/lib/core/analyzers/forbid_modular_get_outside_module_analyzer.dart
@@ -95,7 +95,6 @@ class _ModularGetVisitor extends RecursiveAstVisitor<void> {
   bool _isForbiddenModularGetCall(MethodInvocation node) {
     if (!_isModularGetCall(node)) return false;
     if (_isAllowedType(node)) return false;
-    if (_isInsideAllowedUiClass(node)) return false;
     return true;
   }
 
@@ -119,22 +118,5 @@ class _ModularGetVisitor extends RecursiveAstVisitor<void> {
     final rawType = typeArguments.first.toSource();
     final normalizedType = rawType.split('<').first.split('.').last.trim();
     return config.allowsType(normalizedType);
-  }
-
-  bool _isInsideAllowedUiClass(AstNode node) {
-    final enclosingClass = node.thisOrAncestorOfType<ClassDeclaration>();
-    if (enclosingClass == null) return false;
-
-    final className = enclosingClass.name.lexeme;
-    if (className.endsWith('Page')) return true;
-
-    final superclass =
-        enclosingClass.extendsClause?.superclass.toSource() ?? '';
-    final normalizedSuperclass =
-        superclass.split('<').first.split('.').last.trim();
-
-    return normalizedSuperclass == 'StatelessWidget' ||
-        normalizedSuperclass == 'StatefulWidget' ||
-        normalizedSuperclass.endsWith('Page');
   }
 }

--- a/lib/core/analyzers/forbid_modular_get_outside_module_analyzer.dart
+++ b/lib/core/analyzers/forbid_modular_get_outside_module_analyzer.dart
@@ -66,9 +66,10 @@ class ForbidModularGetOutsideModuleAnalyzer extends BaseAnalyzer {
   ForbidModularGetOutsideModuleConfig _resolveConfig(String path) {
     if (_config != null) return _config;
 
-    final normalizedPath = path.replaceAll('\\', '/');
+    final root =
+        ForbidModularGetOutsideModuleConfigParser.findProjectRoot(path) ?? path;
     return _configCache.putIfAbsent(
-      normalizedPath,
+      root,
       () => ForbidModularGetOutsideModuleConfigParser.loadFromFile(path),
     );
   }

--- a/lib/core/analyzers/forbid_modular_get_outside_module_config.dart
+++ b/lib/core/analyzers/forbid_modular_get_outside_module_config.dart
@@ -1,0 +1,13 @@
+class ForbidModularGetOutsideModuleConfig {
+  const ForbidModularGetOutsideModuleConfig({required this.allowList});
+
+  final Set<String> allowList;
+
+  factory ForbidModularGetOutsideModuleConfig.defaults() {
+    return const ForbidModularGetOutsideModuleConfig(allowList: {'AppRouter'});
+  }
+
+  bool allowsType(String typeName) {
+    return allowList.contains(typeName);
+  }
+}

--- a/lib/core/analyzers/forbid_modular_get_outside_module_config.dart
+++ b/lib/core/analyzers/forbid_modular_get_outside_module_config.dart
@@ -1,12 +1,17 @@
+/// Configuration for [ForbidModularGetOutsideModuleAnalyzer].
 class ForbidModularGetOutsideModuleConfig {
+  /// Creates a config with the given [allowList].
   const ForbidModularGetOutsideModuleConfig({required this.allowList});
 
+  /// Type names exempt from the rule.
   final Set<String> allowList;
 
+  /// Returns the default config with an empty allow-list.
   factory ForbidModularGetOutsideModuleConfig.defaults() {
-    return const ForbidModularGetOutsideModuleConfig(allowList: {'AppRouter'});
+    return const ForbidModularGetOutsideModuleConfig(allowList: {});
   }
 
+  /// Returns true if [typeName] is in the allow-list.
   bool allowsType(String typeName) {
     return allowList.contains(typeName);
   }

--- a/lib/core/analyzers/forbid_modular_get_outside_module_config_parser.dart
+++ b/lib/core/analyzers/forbid_modular_get_outside_module_config_parser.dart
@@ -5,9 +5,13 @@ import 'package:yaml/yaml.dart' as yaml;
 
 import 'forbid_modular_get_outside_module_config.dart';
 
+/// Parses `forbid_modular_get_outside_module` config from `analysis_options.yaml`.
 class ForbidModularGetOutsideModuleConfigParser {
   static const _ruleName = 'forbid_modular_get_outside_module';
 
+  /// Loads rule config for the project that contains [filePath].
+  ///
+  /// Returns defaults when no project root/config can be found or parsing fails.
   static ForbidModularGetOutsideModuleConfig loadFromFile([String? filePath]) {
     final defaults = ForbidModularGetOutsideModuleConfig.defaults();
 
@@ -72,6 +76,9 @@ class ForbidModularGetOutsideModuleConfigParser {
         .toSet();
   }
 
+  /// Finds the nearest ancestor directory containing `analysis_options.yaml`.
+  ///
+  /// Returns `null` when [filePath] is empty or no project root can be found.
   static String? findProjectRoot(String? filePath) {
     if (filePath == null || filePath.isEmpty) return null;
 

--- a/lib/core/analyzers/forbid_modular_get_outside_module_config_parser.dart
+++ b/lib/core/analyzers/forbid_modular_get_outside_module_config_parser.dart
@@ -1,0 +1,103 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:yaml/yaml.dart' as yaml;
+
+import 'forbid_modular_get_outside_module_config.dart';
+
+class ForbidModularGetOutsideModuleConfigParser {
+  static const _ruleName = 'forbid_modular_get_outside_module';
+
+  static ForbidModularGetOutsideModuleConfig loadFromFile([String? filePath]) {
+    final defaults = ForbidModularGetOutsideModuleConfig.defaults();
+
+    try {
+      final projectRoot = _findProjectRoot(filePath);
+      if (projectRoot == null) return defaults;
+
+      final configFile = File(path.join(projectRoot, 'analysis_options.yaml'));
+      if (!configFile.existsSync()) return defaults;
+
+      final parsed = _parseConfigFile(configFile);
+      if (parsed == null) return defaults;
+
+      return ForbidModularGetOutsideModuleConfig(
+        allowList: {...defaults.allowList, ...parsed.allowList},
+      );
+    } catch (_) {
+      return defaults;
+    }
+  }
+
+  static ForbidModularGetOutsideModuleConfig? _parseConfigFile(File file) {
+    final content = file.readAsStringSync();
+    final yamlDoc = yaml.loadYaml(content);
+
+    if (yamlDoc is! Map) return null;
+
+    final configMap = Map<String, dynamic>.from(
+      yamlDoc.map((k, v) => MapEntry(k.toString(), v)),
+    );
+
+    final ruleConfig = _extractRuleConfig(configMap);
+    if (ruleConfig == null) return null;
+
+    return ForbidModularGetOutsideModuleConfig(
+      allowList: _parseStringSet(ruleConfig['allow_list']),
+    );
+  }
+
+  static Map? _extractRuleConfig(Map<String, dynamic> configMap) {
+    final customLint = configMap['custom_lint'];
+    if (customLint is! Map) return null;
+
+    var ruleConfig = customLint[_ruleName];
+    if (ruleConfig is Map) return ruleConfig;
+
+    final rules = customLint['rules'];
+    if (rules is Map) {
+      ruleConfig = rules[_ruleName];
+      if (ruleConfig is Map) return ruleConfig;
+    }
+
+    return null;
+  }
+
+  static Set<String> _parseStringSet(dynamic value) {
+    if (value is! List) return const {};
+
+    return value
+        .map((entry) => entry.toString().trim())
+        .where((entry) => entry.isNotEmpty)
+        .toSet();
+  }
+
+  static String? _findProjectRoot(String? filePath) {
+    if (filePath == null || filePath.isEmpty) return null;
+
+    try {
+      final entity =
+          FileSystemEntity.isDirectorySync(filePath)
+              ? Directory(filePath)
+              : File(filePath).parent;
+
+      var current = entity.absolute;
+      for (var i = 0; i < 10; i++) {
+        final configFile = File(
+          path.join(current.path, 'analysis_options.yaml'),
+        );
+        if (configFile.existsSync()) {
+          return current.path;
+        }
+
+        final parent = current.parent;
+        if (parent.path == current.path) break;
+        current = parent;
+      }
+    } catch (_) {
+      return null;
+    }
+
+    return null;
+  }
+}

--- a/lib/core/analyzers/forbid_modular_get_outside_module_config_parser.dart
+++ b/lib/core/analyzers/forbid_modular_get_outside_module_config_parser.dart
@@ -12,7 +12,7 @@ class ForbidModularGetOutsideModuleConfigParser {
     final defaults = ForbidModularGetOutsideModuleConfig.defaults();
 
     try {
-      final projectRoot = _findProjectRoot(filePath);
+      final projectRoot = findProjectRoot(filePath);
       if (projectRoot == null) return defaults;
 
       final configFile = File(path.join(projectRoot, 'analysis_options.yaml'));
@@ -72,7 +72,7 @@ class ForbidModularGetOutsideModuleConfigParser {
         .toSet();
   }
 
-  static String? _findProjectRoot(String? filePath) {
+  static String? findProjectRoot(String? filePath) {
     if (filePath == null || filePath.isEmpty) return null;
 
     try {

--- a/lib/custom_lint_rules/forbid_modular_get_outside_module.dart
+++ b/lib/custom_lint_rules/forbid_modular_get_outside_module.dart
@@ -8,11 +8,15 @@ import '../core/analyzers/forbid_modular_get_outside_module_analyzer.dart';
 /// (`Modular.get<T>()`) is only permitted in module registration files
 /// (`*_module.dart`), where the object graph is assembled.
 ///
-/// **Exceptions**: 
+/// **Exceptions**:
 /// - `Modular.get<T>()` is allowed in files ending with `_module.dart`.
 /// - Test files (`test/`) and generated files (`.g.dart`, `.freezed.dart`) are skipped.
+/// - `Modular.get<AppRouter>()` is allowed globally.
+/// - UI classes extending `StatelessWidget`, `StatefulWidget`, or `*Page` are exempt.
+/// - Additional globally allowed types can be configured with `allow_list`.
 class ForbidModularGetOutsideModule extends BaseLintRule {
-  ForbidModularGetOutsideModule() : super(BaseLintRule.createLintCode(_analyzer));
+  ForbidModularGetOutsideModule()
+    : super(BaseLintRule.createLintCode(_analyzer));
 
   /// The analyzer instance used by this lint rule.
   static final _analyzer = ForbidModularGetOutsideModuleAnalyzer();

--- a/lib/custom_lint_rules/forbid_modular_get_outside_module.dart
+++ b/lib/custom_lint_rules/forbid_modular_get_outside_module.dart
@@ -18,7 +18,7 @@ class ForbidModularGetOutsideModule extends BaseLintRule {
   ForbidModularGetOutsideModule()
     : super(BaseLintRule.createLintCode(_analyzer));
 
-  /// The analyzer instance used by this lint rule.
+  /// Config injection is for tests only; production always loads from disk via [_resolveConfig].
   static final _analyzer = ForbidModularGetOutsideModuleAnalyzer();
 
   /// Gets the analyzer instance that performs the actual AST traversal and linting logic.

--- a/lib/custom_lint_rules/forbid_modular_get_outside_module.dart
+++ b/lib/custom_lint_rules/forbid_modular_get_outside_module.dart
@@ -11,8 +11,6 @@ import '../core/analyzers/forbid_modular_get_outside_module_analyzer.dart';
 /// **Exceptions**:
 /// - `Modular.get<T>()` is allowed in files ending with `_module.dart`.
 /// - Test files (`test/`) and generated files (`.g.dart`, `.freezed.dart`) are skipped.
-/// - `Modular.get<AppRouter>()` is allowed globally.
-/// - UI classes extending `StatelessWidget`, `StatefulWidget`, or `*Page` are exempt.
 /// - Additional globally allowed types can be configured with `allow_list`.
 class ForbidModularGetOutsideModule extends BaseLintRule {
   ForbidModularGetOutsideModule()

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ripplearc_linter
 description: A custom lint library following best engineering practice 
-version: 0.4.0
+version: 0.4.1
 repository: https://github.com/ripplearc/ripplearc-flutter-lint
 
 environment:

--- a/test/custom_lint_rules/forbid_modular_get_outside_module_test.dart
+++ b/test/custom_lint_rules/forbid_modular_get_outside_module_test.dart
@@ -72,22 +72,6 @@ void main() {
         expect(reporter.errors, hasLength(1));
       });
 
-      test('does not flag Modular.get<AppRouter>() outside a module', () async {
-        const source = r'''
-        class Modular {
-          static T get<T>() => throw UnimplementedError();
-        }
-        class AppRouter {}
-        class NavigationService {
-          NavigationService() {
-            final router = Modular.get<AppRouter>();
-          }
-        }
-        ''';
-        await analyzeCode(source, path: '/lib/navigation_service.dart');
-        expect(reporter.errors, isEmpty);
-      });
-
       test('flags import-prefixed Modular.get', () async {
         await analyzeCode(r'''
 import 'no_such_lib.dart' as fm;

--- a/test/custom_lint_rules/forbid_modular_get_outside_module_test.dart
+++ b/test/custom_lint_rules/forbid_modular_get_outside_module_test.dart
@@ -104,60 +104,6 @@ class MyService {
     });
 
     group('allowed locations', () {
-      test(
-        'does not flag Modular.get inside StatelessWidget classes',
-        () async {
-          const source = r'''
-        class Modular {
-          static T get<T>() => throw UnimplementedError();
-        }
-        class StatelessWidget {}
-        class BuildContext {}
-        class FeatureController {}
-        class LoginPage extends StatelessWidget {
-          Object build(BuildContext context) {
-            return Modular.get<FeatureController>();
-          }
-        }
-        ''';
-          await analyzeCode(source, path: '/lib/login_page.dart');
-          expect(reporter.errors, isEmpty);
-        },
-      );
-
-      test('does not flag Modular.get inside StatefulWidget classes', () async {
-        const source = r'''
-        class Modular {
-          static T get<T>() => throw UnimplementedError();
-        }
-        class StatefulWidget {}
-        class FeatureController {}
-        class LoginFlow extends StatefulWidget {
-          void open() {
-            Modular.get<FeatureController>();
-          }
-        }
-        ''';
-        await analyzeCode(source, path: '/lib/login_flow.dart');
-        expect(reporter.errors, isEmpty);
-      });
-
-      test('does not flag Modular.get inside classes named *Page', () async {
-        const source = r'''
-        class Modular {
-          static T get<T>() => throw UnimplementedError();
-        }
-        class FeatureController {}
-        class CheckoutPage {
-          void open() {
-            Modular.get<FeatureController>();
-          }
-        }
-        ''';
-        await analyzeCode(source, path: '/lib/checkout_page.dart');
-        expect(reporter.errors, isEmpty);
-      });
-
       test('does not flag Modular.get in *_module.dart', () async {
         const source = r'''
         class Modular {
@@ -241,6 +187,57 @@ class MyService {
         ''';
         await analyzeCode(source, path: '/lib/wrong_target.dart');
         expect(reporter.errors, isEmpty);
+      });
+
+      test('flags Modular.get inside StatelessWidget classes', () async {
+        const source = r'''
+        class Modular {
+          static T get<T>() => throw UnimplementedError();
+        }
+        class StatelessWidget {}
+        class BuildContext {}
+        class FeatureController {}
+        class LoginPage extends StatelessWidget {
+          Object build(BuildContext context) {
+            return Modular.get<FeatureController>();
+          }
+        }
+        ''';
+        await analyzeCode(source, path: '/lib/login_page.dart');
+        expect(reporter.errors, hasLength(1));
+      });
+
+      test('flags Modular.get inside StatefulWidget classes', () async {
+        const source = r'''
+        class Modular {
+          static T get<T>() => throw UnimplementedError();
+        }
+        class StatefulWidget {}
+        class FeatureController {}
+        class LoginFlow extends StatefulWidget {
+          void open() {
+            Modular.get<FeatureController>();
+          }
+        }
+        ''';
+        await analyzeCode(source, path: '/lib/login_flow.dart');
+        expect(reporter.errors, hasLength(1));
+      });
+
+      test('flags Modular.get inside classes named *Page', () async {
+        const source = r'''
+        class Modular {
+          static T get<T>() => throw UnimplementedError();
+        }
+        class FeatureController {}
+        class CheckoutPage {
+          void open() {
+            Modular.get<FeatureController>();
+          }
+        }
+        ''';
+        await analyzeCode(source, path: '/lib/checkout_page.dart');
+        expect(reporter.errors, hasLength(1));
       });
 
       test('supports allow_list from analysis_options.yaml', () async {

--- a/test/custom_lint_rules/forbid_modular_get_outside_module_test.dart
+++ b/test/custom_lint_rules/forbid_modular_get_outside_module_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:ripplearc_linter/custom_lint_rules/forbid_modular_get_outside_module.dart';
@@ -10,9 +12,19 @@ void main() {
     late ForbidModularGetOutsideModule rule;
     late TestErrorReporter reporter;
     late CompilationUnit unit;
+    final tempDirectories = <Directory>[];
 
     setUp(() {
       rule = ForbidModularGetOutsideModule();
+    });
+
+    tearDown(() async {
+      for (final directory in tempDirectories) {
+        if (await directory.exists()) {
+          await directory.delete(recursive: true);
+        }
+      }
+      tempDirectories.clear();
     });
 
     Future<void> analyzeCode(String sourceCode, {required String path}) async {
@@ -39,7 +51,10 @@ void main() {
           }
         }
         ''';
-        await analyzeCode(source, path: '/lib/features/project_dropdown_bloc.dart');
+        await analyzeCode(
+          source,
+          path: '/lib/features/project_dropdown_bloc.dart',
+        );
         expect(reporter.errors, hasLength(1));
       });
 
@@ -57,9 +72,24 @@ void main() {
         expect(reporter.errors, hasLength(1));
       });
 
+      test('does not flag Modular.get<AppRouter>() outside a module', () async {
+        const source = r'''
+        class Modular {
+          static T get<T>() => throw UnimplementedError();
+        }
+        class AppRouter {}
+        class NavigationService {
+          NavigationService() {
+            final router = Modular.get<AppRouter>();
+          }
+        }
+        ''';
+        await analyzeCode(source, path: '/lib/navigation_service.dart');
+        expect(reporter.errors, isEmpty);
+      });
+
       test('flags import-prefixed Modular.get', () async {
-        await analyzeCode(
-          r'''
+        await analyzeCode(r'''
 import 'no_such_lib.dart' as fm;
 
 class R {}
@@ -69,9 +99,7 @@ class MyService {
     fm.Modular.get<R>();
   }
 }
-''',
-          path: '/lib/prefixed_service.dart',
-        );
+''', path: '/lib/prefixed_service.dart');
         expect(reporter.errors, hasLength(1));
       });
 
@@ -92,6 +120,60 @@ class MyService {
     });
 
     group('allowed locations', () {
+      test(
+        'does not flag Modular.get inside StatelessWidget classes',
+        () async {
+          const source = r'''
+        class Modular {
+          static T get<T>() => throw UnimplementedError();
+        }
+        class StatelessWidget {}
+        class BuildContext {}
+        class FeatureController {}
+        class LoginPage extends StatelessWidget {
+          Object build(BuildContext context) {
+            return Modular.get<FeatureController>();
+          }
+        }
+        ''';
+          await analyzeCode(source, path: '/lib/login_page.dart');
+          expect(reporter.errors, isEmpty);
+        },
+      );
+
+      test('does not flag Modular.get inside StatefulWidget classes', () async {
+        const source = r'''
+        class Modular {
+          static T get<T>() => throw UnimplementedError();
+        }
+        class StatefulWidget {}
+        class FeatureController {}
+        class LoginFlow extends StatefulWidget {
+          void open() {
+            Modular.get<FeatureController>();
+          }
+        }
+        ''';
+        await analyzeCode(source, path: '/lib/login_flow.dart');
+        expect(reporter.errors, isEmpty);
+      });
+
+      test('does not flag Modular.get inside classes named *Page', () async {
+        const source = r'''
+        class Modular {
+          static T get<T>() => throw UnimplementedError();
+        }
+        class FeatureController {}
+        class CheckoutPage {
+          void open() {
+            Modular.get<FeatureController>();
+          }
+        }
+        ''';
+        await analyzeCode(source, path: '/lib/checkout_page.dart');
+        expect(reporter.errors, isEmpty);
+      });
+
       test('does not flag Modular.get in *_module.dart', () async {
         const source = r'''
         class Modular {
@@ -139,7 +221,10 @@ class MyService {
           Modular.get<int>();
         }
         ''';
-        await analyzeCode(source, path: '/home/user/myproject/test/some_test.dart');
+        await analyzeCode(
+          source,
+          path: '/home/user/myproject/test/some_test.dart',
+        );
         expect(reporter.errors, isEmpty);
       });
 
@@ -173,6 +258,40 @@ class MyService {
         await analyzeCode(source, path: '/lib/wrong_target.dart');
         expect(reporter.errors, isEmpty);
       });
+
+      test('supports allow_list from analysis_options.yaml', () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'forbid_modular_get_config_test_',
+        );
+        tempDirectories.add(tempDir);
+
+        final analysisOptions = File('${tempDir.path}/analysis_options.yaml');
+        await analysisOptions.writeAsString('''
+custom_lint:
+  rules:
+    forbid_modular_get_outside_module:
+      allow_list:
+        - GlobalAnalytics
+''');
+
+        const source = r'''
+        class Modular {
+          static T get<T>() => throw UnimplementedError();
+        }
+        class GlobalAnalytics {}
+        class AnalyticsConsumer {
+          AnalyticsConsumer() {
+            Modular.get<GlobalAnalytics>();
+          }
+        }
+        ''';
+
+        await analyzeCode(
+          source,
+          path: '${tempDir.path}/lib/analytics_consumer.dart',
+        );
+        expect(reporter.errors, isEmpty);
+      });
     });
 
     group('rule metadata', () {
@@ -188,12 +307,18 @@ class MyService {
 
     group('direct analyze() call', () {
       test('analyze() returns empty list (bypass check)', () {
-        const source = 'class Modular { static T get<T>() => throw ""; } void f() { Modular.get<int>(); }';
+        const source =
+            'class Modular { static T get<T>() => throw ""; } void f() { Modular.get<int>(); }';
         final parseResult = parseString(content: source);
         final unit = parseResult.unit;
-        
+
         final issues = rule.analyzer.analyze(unit);
-        expect(issues, isEmpty, reason: 'analyze() should return an empty list to prevent path-unaware analysis');
+        expect(
+          issues,
+          isEmpty,
+          reason:
+              'analyze() should return an empty list to prevent path-unaware analysis',
+        );
       });
     });
   });


### PR DESCRIPTION
 ## Summary

  Re-enable and harden forbid_modular_get_outside_module so it enforces module boundaries without blocking legitimate global navigation and presentation-layer access.

  ## What changed

  - Added a built-in exception for Modular.get<AppRouter>()
  - Exempted Modular.get<T>() usage inside UI classes extending StatelessWidget, StatefulWidget, or *Page
  - Added optional allow_list support in analysis_options.yaml for additional approved global services
  - Updated rule docs, example usage, changelog, and package version
  - Expanded test coverage for:
      - normal violations
      - AppRouter exception
      - widget/page exceptions
      - allow_list config loading

  ## Configuration

  Projects can extend the allowed global types with:

  custom_lint:
    rules:
      forbid_modular_get_outside_module:
        allow_list:
          - GlobalAnalytics
          - AppEnvironment

  ## Why

  - feature/module-specific dependencies must still be injected properly
  - only narrowly approved global services can bypass the rule
  - UI/router access is allowed where it is operationally necessary

  ## Verification

  - dart test test/custom_lint_rules/forbid_modular_get_outside_module_test.dart
  - dart run ripplearc_linter:standalone_checker --rules forbid_modular_get_outside_module lib/