### PR TITLE
[CA-633]feat: add restrict_core_icon_data rule to standalone checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.4.1 - Fix Restrict Core Icon Data Scope (patch)
+
+### Bug Fixes
+
+- **Fixed `restrict_core_icon_data` false positives inside `coreui`**: The `restrict_core_icon_data` rule previously only exempted the `/lib/src/theme/icons/` directory. It has been updated to exempt the entire `coreui` package (`/coreui/lib/` and `/coreui/test/`), resolving false positive violations when `CoreIconData` is used legitimately inside internal `coreui` components (like `core_icon.dart`).
+- **Added `restrict_core_icon_data` to standalone checker**: This rule is now fully supported by the `standalone_checker` CLI tool.
+
+---
+
 ## 0.4.0 - Forbid Modular.get Outside Module (minor)
 
 ### New Rule

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ This configuration file includes all our custom lint rules:
 - `document_interface` - Enforce documentation on abstract classes and their public methods
 - `prevent_feature_module_dependencies` - Enforce feature module independence by preventing features from depending on other features
 - `prevent_library_module_dependencies` - Enforce library module independence by preventing libraries from depending on features
+- `restrict_core_icon_data` - Restrict `CoreIconData` and `CoreMaterialIcons` usage to the `coreui` package
 
 #### Rule Configuration
 - Each rule is listed under the `rules` section
@@ -233,6 +234,7 @@ To update your project to use the latest version of `ripplearc_linter` and enabl
        - no_internal_method_docs
        - prevent_feature_module_dependencies
        - prevent_library_module_dependencies
+       - restrict_core_icon_data
      ```
    - Only include the rules you want to enforce in your project.
 

--- a/bin/standalone_checker.dart
+++ b/bin/standalone_checker.dart
@@ -21,6 +21,7 @@ import 'package:ripplearc_linter/core/analyzers/forbid_helper_util_naming_analyz
 import 'package:ripplearc_linter/core/analyzers/prevent_feature_module_dependencies_analyzer.dart';
 import 'package:ripplearc_linter/core/analyzers/prevent_library_module_dependencies_analyzer.dart';
 import 'package:ripplearc_linter/core/analyzers/forbid_modular_get_outside_module_analyzer.dart';
+import 'package:ripplearc_linter/core/analyzers/forbid_raw_icon_and_image_usage_analyzer.dart';
 
 import 'package:path/path.dart' as p;
 import 'package:analyzer/dart/analysis/utilities.dart';
@@ -86,6 +87,7 @@ class StandaloneLintChecker {
       FeatureModuleIsolationAnalyzer(),
       LibraryModuleDependenciesAnalyzer(),
       ForbidModularGetOutsideModuleAnalyzer(),
+      ForbidRawIconAndImageUsageAnalyzer(),
     ];
   }
 
@@ -106,6 +108,7 @@ class StandaloneLintChecker {
     'avoid_static_typography',
     'no_direct_instantiation',
     'forbid_helper_util_naming',
+    'forbid_raw_icon_and_image_usage',
   };
 
   /// Analyzes the given files and directories for linting issues.
@@ -370,7 +373,7 @@ void main(List<String> args) async {
       'standalone_checker [--rules rule1,rule2] <files_or_directories> (after global activate)',
     );
     print(
-      'Available rules: avoid_static_typography, avoid_static_colors, forbid_forced_unwrapping, no_direct_instantiation, sealed_over_dynamic, private_subject, specific_exception_types, document_fake_parameters, document_interface, no_internal_method_docs, todo_with_story_links, no_optional_operators_in_tests, prefer_fake_over_mock, test_file_mutation_coverage , prevent_feature_module_dependencies, forbid_modular_get_outside_module',
+      'Available rules: avoid_static_typography, avoid_static_colors, forbid_forced_unwrapping, no_direct_instantiation, sealed_over_dynamic, private_subject, specific_exception_types, document_fake_parameters, document_interface, no_internal_method_docs, todo_with_story_links, no_optional_operators_in_tests, prefer_fake_over_mock, test_file_mutation_coverage , prevent_feature_module_dependencies, forbid_modular_get_outside_module, forbid_raw_icon_and_image_usage',
     );
     exit(1);
   }

--- a/bin/standalone_checker.dart
+++ b/bin/standalone_checker.dart
@@ -22,6 +22,7 @@ import 'package:ripplearc_linter/core/analyzers/prevent_feature_module_dependenc
 import 'package:ripplearc_linter/core/analyzers/prevent_library_module_dependencies_analyzer.dart';
 import 'package:ripplearc_linter/core/analyzers/forbid_modular_get_outside_module_analyzer.dart';
 import 'package:ripplearc_linter/core/analyzers/forbid_raw_icon_and_image_usage_analyzer.dart';
+import 'package:ripplearc_linter/core/analyzers/restrict_core_icon_data_analyzer.dart';
 
 import 'package:path/path.dart' as p;
 import 'package:analyzer/dart/analysis/utilities.dart';
@@ -88,6 +89,7 @@ class StandaloneLintChecker {
       LibraryModuleDependenciesAnalyzer(),
       ForbidModularGetOutsideModuleAnalyzer(),
       ForbidRawIconAndImageUsageAnalyzer(),
+      RestrictCoreIconDataAnalyzer(),
     ];
   }
 
@@ -109,6 +111,7 @@ class StandaloneLintChecker {
     'no_direct_instantiation',
     'forbid_helper_util_naming',
     'forbid_raw_icon_and_image_usage',
+    'restrict_core_icon_data',
   };
 
   /// Analyzes the given files and directories for linting issues.
@@ -373,7 +376,7 @@ void main(List<String> args) async {
       'standalone_checker [--rules rule1,rule2] <files_or_directories> (after global activate)',
     );
     print(
-      'Available rules: avoid_static_typography, avoid_static_colors, forbid_forced_unwrapping, no_direct_instantiation, sealed_over_dynamic, private_subject, specific_exception_types, document_fake_parameters, document_interface, no_internal_method_docs, todo_with_story_links, no_optional_operators_in_tests, prefer_fake_over_mock, test_file_mutation_coverage , prevent_feature_module_dependencies, forbid_modular_get_outside_module, forbid_raw_icon_and_image_usage',
+      'Available rules: avoid_static_typography, avoid_static_colors, forbid_forced_unwrapping, no_direct_instantiation, sealed_over_dynamic, private_subject, specific_exception_types, document_fake_parameters, document_interface, no_internal_method_docs, todo_with_story_links, no_optional_operators_in_tests, prefer_fake_over_mock, test_file_mutation_coverage , prevent_feature_module_dependencies, forbid_modular_get_outside_module, forbid_raw_icon_and_image_usage, restrict_core_icon_data',
     );
     exit(1);
   }

--- a/lib/core/analyzers/forbid_raw_icon_and_image_usage_analyzer.dart
+++ b/lib/core/analyzers/forbid_raw_icon_and_image_usage_analyzer.dart
@@ -44,7 +44,8 @@ class ForbidRawIconAndImageUsageAnalyzer extends BaseAnalyzer {
   @override
   bool shouldSkipFile(String path) {
     final normalized = path.replaceAll('\\', '/');
-    return normalized.contains('/coreui/lib/') || normalized.contains('/coreui/test/');
+    return normalized.contains('/coreui/lib/') ||
+        normalized.contains('/coreui/test/');
   }
 }
 
@@ -67,19 +68,37 @@ class _ForbidRawIconAndImageUsageVisitor extends RecursiveAstVisitor<void> {
               'Direct usage of Icon() is restricted. Use CoreIcons and coreui components instead.',
         ),
       );
-    } else if (typeName == 'Image') {
-      final constructor = constructorName.name?.name;
-      if (constructor == 'asset') {
-        issues.add(
-          analyzer.createIssue(
-            node,
-            customMessage:
-                'Direct usage of Image.asset() is restricted. Use coreui components instead.',
-          ),
-        );
-      }
+    }
+
+    final importPrefix = constructorName.type.importPrefix?.name.lexeme;
+    if (importPrefix == 'Image' && typeName == 'asset') {
+      issues.add(
+        analyzer.createIssue(
+          node,
+          customMessage:
+              'Direct usage of Image.asset() is restricted. Use coreui components instead.',
+        ),
+      );
     }
 
     super.visitInstanceCreationExpression(node);
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    final target = node.target;
+    if (target is SimpleIdentifier &&
+        target.name == 'Image' &&
+        node.methodName.name == 'asset') {
+      issues.add(
+        analyzer.createIssue(
+          node,
+          customMessage:
+              'Direct usage of Image.asset() is restricted. Use coreui components instead.',
+        ),
+      );
+    }
+
+    super.visitMethodInvocation(node);
   }
 }

--- a/lib/core/analyzers/forbid_raw_icon_and_image_usage_analyzer.dart
+++ b/lib/core/analyzers/forbid_raw_icon_and_image_usage_analyzer.dart
@@ -1,0 +1,85 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'base_analyzer.dart';
+import '../models/lint_issue.dart';
+
+/// Analyzer that prevents direct usage of raw Flutter icons and Image.asset.
+///
+/// This rule enforces icon abstraction by requiring developers to use the `CoreIcons`
+/// constants instead of directly instantiating `Icon` with `Icons.xxx` or using `Image.asset`.
+///
+/// Example of code that triggers this rule:
+/// ```dart
+/// final icon = Icon(Icons.import_contacts); // LINT
+/// final image = Image.asset('assets/image.png'); // LINT
+/// ```
+class ForbidRawIconAndImageUsageAnalyzer extends BaseAnalyzer {
+  @override
+  String get ruleName => 'forbid_raw_icon_and_image_usage';
+
+  @override
+  String get problemMessage =>
+      'Raw Flutter icons and direct Image.asset usages are restricted. Use CoreIcons and coreui components instead.';
+
+  @override
+  String get correctionMessage =>
+      'Use CoreIcons constants or properly abstracted coreui components.';
+
+  @override
+  List<LintIssue> analyze(CompilationUnit unit) {
+    return [];
+  }
+
+  @override
+  List<LintIssue> analyzeWithResolver(CompilationUnit unit, dynamic resolver) {
+    final path = resolver.path ?? '';
+    if (shouldSkipFile(path)) {
+      return [];
+    }
+    final visitor = _ForbidRawIconAndImageUsageVisitor(this);
+    unit.accept(visitor);
+    return visitor.issues;
+  }
+
+  @override
+  bool shouldSkipFile(String path) {
+    final normalized = path.replaceAll('\\', '/');
+    return normalized.contains('/coreui/lib/') || normalized.contains('/coreui/test/');
+  }
+}
+
+class _ForbidRawIconAndImageUsageVisitor extends RecursiveAstVisitor<void> {
+  final ForbidRawIconAndImageUsageAnalyzer analyzer;
+  final List<LintIssue> issues = [];
+
+  _ForbidRawIconAndImageUsageVisitor(this.analyzer);
+
+  @override
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    final constructorName = node.constructorName;
+    final typeName = constructorName.type.name2.lexeme;
+
+    if (typeName == 'Icon') {
+      issues.add(
+        analyzer.createIssue(
+          node,
+          customMessage:
+              'Direct usage of Icon() is restricted. Use CoreIcons and coreui components instead.',
+        ),
+      );
+    } else if (typeName == 'Image') {
+      final constructor = constructorName.name?.name;
+      if (constructor == 'asset') {
+        issues.add(
+          analyzer.createIssue(
+            node,
+            customMessage:
+                'Direct usage of Image.asset() is restricted. Use coreui components instead.',
+          ),
+        );
+      }
+    }
+
+    super.visitInstanceCreationExpression(node);
+  }
+}

--- a/lib/custom_lint_rules/forbid_raw_icon_and_image_usage.dart
+++ b/lib/custom_lint_rules/forbid_raw_icon_and_image_usage.dart
@@ -1,0 +1,13 @@
+import '../core/base_lint_rule.dart';
+import '../core/analyzers/forbid_raw_icon_and_image_usage_analyzer.dart';
+import '../core/analyzers/base_analyzer.dart';
+
+class ForbidRawIconAndImageUsage extends BaseLintRule {
+  ForbidRawIconAndImageUsage()
+    : super(BaseLintRule.createLintCode(_analyzer), includeTests: true);
+
+  static final _analyzer = ForbidRawIconAndImageUsageAnalyzer();
+
+  @override
+  BaseAnalyzer get analyzer => _analyzer;
+}

--- a/lib/ripplearc_linter.dart
+++ b/lib/ripplearc_linter.dart
@@ -21,6 +21,7 @@ import 'custom_lint_rules/test_file_mutation_coverage.dart';
 import 'custom_lint_rules/prevent_feature_module_dependencies.dart';
 import 'custom_lint_rules/prevent_library_module_dependencies.dart';
 import 'custom_lint_rules/restrict_core_icon_data.dart';
+import 'custom_lint_rules/forbid_raw_icon_and_image_usage.dart';
 
 PluginBase createPlugin() => _RipplearcLintRules();
 
@@ -49,5 +50,6 @@ class _RipplearcLintRules extends PluginBase {
     PreventFeatureModuleDependencies(),
     PreventLibraryModuleDependencies(),
     RestrictCoreIconData(),
+    ForbidRawIconAndImageUsage(),
   ];
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ripplearc_linter
 description: A custom lint library following best engineering practice 
-version: 0.4.0
+version: 0.4.1
 repository: https://github.com/ripplearc/ripplearc-flutter-lint
 
 environment:

--- a/test/custom_lint_rules/forbid_raw_icon_and_image_usage_test.dart
+++ b/test/custom_lint_rules/forbid_raw_icon_and_image_usage_test.dart
@@ -1,0 +1,399 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:ripplearc_linter/custom_lint_rules/forbid_raw_icon_and_image_usage.dart';
+import 'package:ripplearc_linter/core/analyzers/forbid_raw_icon_and_image_usage_analyzer.dart';
+import 'package:test/test.dart';
+import '../utils/custom_lint_resolver.dart';
+import '../utils/test_error_reporter.dart';
+
+void main() {
+  group('ForbidRawIconAndImageUsage', () {
+    late ForbidRawIconAndImageUsage rule;
+    late TestErrorReporter reporter;
+    late CompilationUnit unit;
+
+    setUp(() {
+      rule = ForbidRawIconAndImageUsage();
+    });
+
+    Future<void> analyzeCode(String sourceCode, {required String path}) async {
+      reporter = TestErrorReporter();
+      final parseResult = parseString(content: sourceCode);
+      unit = parseResult.unit;
+      rule.run(
+        TestCustomLintResolver(unit, path: path),
+        reporter,
+        TestCustomLintContext(unit),
+      );
+    }
+
+    group('Icon() usage', () {
+      test('should flag Icon() constructor in app code', () async {
+        const source = '''
+        class Icons {
+          static const home = 1;
+        }
+        class Icon {
+          const Icon(dynamic iconData);
+        }
+        class MyWidget {
+          void build() {
+            final icon = new Icon(Icons.home);
+          }
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/widgets/my_widget.dart');
+        expect(reporter.errors, hasLength(1));
+      });
+
+      test('should flag Icon() constructor in test files', () async {
+        const source = '''
+        class Icons {
+          static const home = 1;
+        }
+        class Icon {
+          const Icon(dynamic iconData);
+        }
+        void main() {
+          test('example', () {
+            final icon = new Icon(Icons.home);
+          });
+        }
+        ''';
+        await analyzeCode(source, path: 'test/widgets/my_widget_test.dart');
+        expect(reporter.errors, hasLength(1));
+      });
+
+      test('should flag const Icon() usage', () async {
+        const source = '''
+        class Icons {
+          static const star = 1;
+        }
+        class Icon {
+          const Icon(dynamic iconData);
+        }
+        class MyWidget {
+          static const icon = const Icon(Icons.star);
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/widgets/my_widget.dart');
+        expect(reporter.errors, hasLength(1));
+      });
+
+      test('should flag multiple Icon() usages', () async {
+        const source = '''
+        class Icons {
+          static const home = 1;
+          static const star = 2;
+        }
+        class Icon {
+          const Icon(dynamic iconData);
+        }
+        class MyWidget {
+          void build() {
+            final icon1 = new Icon(Icons.home);
+            final icon2 = new Icon(Icons.star);
+          }
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/widgets/my_widget.dart');
+        expect(reporter.errors, hasLength(2));
+      });
+
+      test('should not flag Icon() in coreui/lib path', () async {
+        const source = '''
+        class Icons {
+          static const home = 1;
+        }
+        class Icon {
+          const Icon(dynamic iconData);
+        }
+        class CoreIconWidget {
+          void build() {
+            final icon = new Icon(Icons.home);
+          }
+        }
+        ''';
+        await analyzeCode(
+          source,
+          path: 'packages/coreui/lib/src/components/core_icon.dart',
+        );
+        expect(reporter.errors, isEmpty);
+      });
+
+      test('should not flag Icon() in coreui/test path', () async {
+        const source = '''
+        class Icons {
+          static const home = 1;
+        }
+        class Icon {
+          const Icon(dynamic iconData);
+        }
+        void main() {
+          test('example', () {
+            final icon = new Icon(Icons.home);
+          });
+        }
+        ''';
+        await analyzeCode(
+          source,
+          path: 'packages/coreui/test/components/core_icon_test.dart',
+        );
+        expect(reporter.errors, isEmpty);
+      });
+    });
+
+    group('Image.asset() path exclusion', () {
+      test('should not flag Image constructors in coreui/lib path', () async {
+        const source = '''
+        class Image {
+          Image.asset(String name);
+          Image.network(String url);
+        }
+        class CoreImageWidget {
+          void build() {
+            final image = new Image.asset('assets/image.png');
+            final network = new Image.network('https://example.com');
+          }
+        }
+        ''';
+        await analyzeCode(
+          source,
+          path: 'packages/coreui/lib/src/components/core_image.dart',
+        );
+        expect(reporter.errors, isEmpty);
+      });
+
+      test('should not flag Image constructors in coreui/test path', () async {
+        const source = '''
+        class Image {
+          Image.asset(String name);
+        }
+        void main() {
+          test('example', () {
+            final image = new Image.asset('assets/image.png');
+          });
+        }
+        ''';
+        await analyzeCode(
+          source,
+          path: 'packages/coreui/test/components/core_image_test.dart',
+        );
+        expect(reporter.errors, isEmpty);
+      });
+    });
+
+    group('shouldSkipFile', () {
+      late ForbidRawIconAndImageUsageAnalyzer analyzer;
+
+      setUp(() {
+        analyzer = ForbidRawIconAndImageUsageAnalyzer();
+      });
+
+      test('should skip files in coreui/lib/', () {
+        expect(
+          analyzer.shouldSkipFile(
+            'packages/coreui/lib/src/components/core_icon.dart',
+          ),
+          isTrue,
+        );
+      });
+
+      test('should skip files in coreui/test/', () {
+        expect(
+          analyzer.shouldSkipFile(
+            'packages/coreui/test/components/core_icon_test.dart',
+          ),
+          isTrue,
+        );
+      });
+
+      test('should not skip app lib files', () {
+        expect(analyzer.shouldSkipFile('lib/widgets/my_widget.dart'), isFalse);
+      });
+
+      test('should not skip app test files', () {
+        expect(
+          analyzer.shouldSkipFile('test/widgets/my_widget_test.dart'),
+          isFalse,
+        );
+      });
+
+      test('should handle Windows-style paths', () {
+        expect(
+          analyzer.shouldSkipFile(
+            r'packages\coreui\lib\src\components\core_icon.dart',
+          ),
+          isTrue,
+        );
+        expect(
+          analyzer.shouldSkipFile(
+            r'packages\coreui\test\components\core_icon_test.dart',
+          ),
+          isTrue,
+        );
+      });
+    });
+
+    group('edge cases', () {
+      test('should not flag unrelated classes', () async {
+        const source = '''
+        class CustomIcon {
+          const CustomIcon(dynamic data);
+        }
+        class MyWidget {
+          void build() {
+            final icon = new CustomIcon('data');
+          }
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/widgets/my_widget.dart');
+        expect(reporter.errors, isEmpty);
+      });
+
+      test(
+        'should not flag CoreIcons usage (the approved replacement)',
+        () async {
+          const source = '''
+        class CoreIcons {
+          static const arrowRight = 'icon_data';
+        }
+        class MyWidget {
+          void build() {
+            final icon = CoreIcons.arrowRight;
+          }
+        }
+        ''';
+          await analyzeCode(source, path: 'lib/widgets/my_widget.dart');
+          expect(reporter.errors, isEmpty);
+        },
+      );
+
+      test('should handle empty source code', () async {
+        const source = '';
+        await analyzeCode(source, path: 'lib/widgets/empty.dart');
+        expect(reporter.errors, isEmpty);
+      });
+
+      test('should handle source with no violations', () async {
+        const source = '''
+        class MyWidget {
+          void build() {
+            print('no icons here');
+          }
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/widgets/my_widget.dart');
+        expect(reporter.errors, isEmpty);
+      });
+    });
+
+    group('rule metadata', () {
+      test('rule name', () {
+        expect(rule.code.name, equals('forbid_raw_icon_and_image_usage'));
+      });
+
+      test('problem message mentions raw icons and Image.asset', () {
+        expect(rule.code.problemMessage, contains('Raw Flutter icons'));
+        expect(rule.code.problemMessage, contains('Image.asset'));
+      });
+
+      test('rule includes test files', () {
+        expect(
+          ForbidRawIconAndImageUsageAnalyzer().shouldSkipFile(
+            'test/my_test.dart',
+          ),
+          isFalse,
+        );
+      });
+    });
+
+    group('analyzer interface', () {
+      test('analyze() returns empty list (bypass check)', () {
+        const source = '''
+        class Icon {
+          const Icon(dynamic iconData);
+        }
+        class Icons {
+          static const home = 1;
+        }
+        void f() { new Icon(Icons.home); }
+        ''';
+        final parseResult = parseString(content: source);
+        final unit = parseResult.unit;
+
+        final issues = rule.analyzer.analyze(unit);
+        expect(
+          issues,
+          isEmpty,
+          reason:
+              'analyze() should return an empty list to prevent path-unaware analysis',
+        );
+      });
+
+      test(
+        'analyzeWithResolver returns issues for Icon() on non-excluded path',
+        () {
+          const source = '''
+        class Icon {
+          const Icon(dynamic iconData);
+        }
+        class Icons {
+          static const home = 1;
+        }
+        void f() { new Icon(Icons.home); }
+        ''';
+          final parseResult = parseString(content: source);
+          final unit = parseResult.unit;
+          final resolver = TestCustomLintResolver(unit, path: 'lib/main.dart');
+
+          final issues = rule.analyzer.analyzeWithResolver(unit, resolver);
+          expect(issues, hasLength(1));
+          expect(
+            issues.first.ruleName,
+            equals('forbid_raw_icon_and_image_usage'),
+          );
+          expect(issues.first.message, contains('Icon()'));
+        },
+      );
+
+      test('analyzeWithResolver returns empty for excluded coreui path', () {
+        const source = '''
+        class Icon {
+          const Icon(dynamic iconData);
+        }
+        class Icons {
+          static const home = 1;
+        }
+        void f() { new Icon(Icons.home); }
+        ''';
+        final parseResult = parseString(content: source);
+        final unit = parseResult.unit;
+        final resolver = TestCustomLintResolver(
+          unit,
+          path: 'packages/coreui/lib/src/core_icon.dart',
+        );
+
+        final issues = rule.analyzer.analyzeWithResolver(unit, resolver);
+        expect(issues, isEmpty);
+      });
+
+      test('analyzer exposes correct rule name', () {
+        expect(
+          rule.analyzer.ruleName,
+          equals('forbid_raw_icon_and_image_usage'),
+        );
+      });
+
+      test('analyzer exposes problem message', () {
+        expect(rule.analyzer.problemMessage, isNotEmpty);
+        expect(rule.analyzer.problemMessage, contains('Raw Flutter icons'));
+      });
+
+      test('analyzer exposes correction message', () {
+        expect(rule.analyzer.correctionMessage, isNotEmpty);
+        expect(rule.analyzer.correctionMessage, contains('CoreIcons'));
+      });
+    });
+  });
+}

--- a/test/custom_lint_rules/forbid_raw_icon_and_image_usage_test.dart
+++ b/test/custom_lint_rules/forbid_raw_icon_and_image_usage_test.dart
@@ -143,7 +143,106 @@ void main() {
       });
     });
 
-    group('Image.asset() path exclusion', () {
+    group('Image.asset() usage', () {
+      test('should flag Image.asset() in app code', () async {
+        const source = '''
+        class Image {
+          Image.asset(String name);
+        }
+        class MyWidget {
+          void build() {
+            final image = new Image.asset('assets/image.png');
+          }
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/widgets/my_widget.dart');
+        expect(reporter.errors, hasLength(1));
+      });
+
+      test('should flag Image.asset() in test files', () async {
+        const source = '''
+        class Image {
+          Image.asset(String name);
+        }
+        void main() {
+          test('example', () {
+            final image = new Image.asset('assets/logo.png');
+          });
+        }
+        ''';
+        await analyzeCode(source, path: 'test/widgets/my_widget_test.dart');
+        expect(reporter.errors, hasLength(1));
+      });
+
+      test('should flag multiple Image.asset() usages', () async {
+        const source = '''
+        class Image {
+          Image.asset(String name);
+        }
+        class MyWidget {
+          void build() {
+            final img1 = new Image.asset('assets/image1.png');
+            final img2 = new Image.asset('assets/image2.png');
+          }
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/widgets/my_widget.dart');
+        expect(reporter.errors, hasLength(2));
+      });
+
+      test('should not flag Image.network() (only Image.asset is restricted)',
+          () async {
+        const source = '''
+        class Image {
+          Image.network(String url);
+        }
+        class MyWidget {
+          void build() {
+            final image = new Image.network('https://example.com/img.png');
+          }
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/widgets/my_widget.dart');
+        expect(reporter.errors, isEmpty);
+      });
+
+      test('should not flag plain Image() default constructor', () async {
+        const source = '''
+        class Image {
+          Image();
+        }
+        class MyWidget {
+          void build() {
+            final image = new Image();
+          }
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/widgets/my_widget.dart');
+        expect(reporter.errors, isEmpty);
+      });
+
+      test('should flag both Icon() and Image.asset() in same file', () async {
+        const source = '''
+        class Icons {
+          static const home = 1;
+        }
+        class Icon {
+          const Icon(dynamic iconData);
+        }
+        class Image {
+          Image.asset(String name);
+        }
+        class MyWidget {
+          void build() {
+            final icon = new Icon(Icons.home);
+            final image = new Image.asset('assets/image.png');
+          }
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/widgets/my_widget.dart');
+        expect(reporter.errors, hasLength(2));
+      });
+
       test('should not flag Image constructors in coreui/lib path', () async {
         const source = '''
         class Image {

--- a/test/standalone_checker_test.dart
+++ b/test/standalone_checker_test.dart
@@ -22,10 +22,10 @@ void main() {
     });
 
     group('Bridge Initialization and Configuration', () {
-      test('should initialize with all 18 custom lint analyzers', () {
+      test('should initialize with all 20 custom lint analyzers', () {
         final checker = StandaloneLintChecker();
 
-        expect(checker.analyzers.length, equals(19));
+        expect(checker.analyzers.length, equals(20));
 
         final ruleNames = checker.analyzers.map((a) => a.ruleName).toSet();
         final expectedRules = {
@@ -48,6 +48,7 @@ void main() {
           'prevent_library_module_dependencies',
           'forbid_modular_get_outside_module',
           'forbid_raw_icon_and_image_usage',
+          'restrict_core_icon_data',
         };
 
         expect(ruleNames, equals(expectedRules));

--- a/test/standalone_checker_test.dart
+++ b/test/standalone_checker_test.dart
@@ -25,7 +25,7 @@ void main() {
       test('should initialize with all 18 custom lint analyzers', () {
         final checker = StandaloneLintChecker();
 
-        expect(checker.analyzers.length, equals(18));
+        expect(checker.analyzers.length, equals(19));
 
         final ruleNames = checker.analyzers.map((a) => a.ruleName).toSet();
         final expectedRules = {

--- a/test/standalone_checker_test.dart
+++ b/test/standalone_checker_test.dart
@@ -47,6 +47,7 @@ void main() {
           'feature_module_isolation',
           'prevent_library_module_dependencies',
           'forbid_modular_get_outside_module',
+          'forbid_raw_icon_and_image_usage',
         };
 
         expect(ruleNames, equals(expectedRules));


### PR DESCRIPTION
### Summary
This pull request releases version 0.4.1 of the `ripplearc_linter` package, focusing on improving the `restrict_core_icon_data` lint rule and updating documentation and tests accordingly. The main changes address a bug with false positives in the rule, expand its support, and update references throughout the project.

### Lint rule improvements

* The `restrict_core_icon_data` rule now exempts the entire `coreui` package (`/coreui/lib/` and `/coreui/test/`), fixing false positives when `CoreIconData` is used internally within `coreui` components.
* The `restrict_core_icon_data` rule is now fully supported by the `standalone_checker` CLI tool.

### Documentation updates

* Updated the `CHANGELOG.md` to describe the bug fix and new support for the rule in the CLI tool.
* Added `restrict_core_icon_data` to the list of available rules and example configuration in the `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R178) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R237)

### Version bump

* Bumped the package version to `0.4.1` in `pubspec.yaml`.

### Test updates

* Updated the `standalone_checker_test.dart` to expect 19 custom lint analyzers and to include `restrict_core_icon_data` in the tested rule set. [[1]](diffhunk://#diff-d603a75df5fa6c9be17834eebe92448943e16e0075dc4b18d4fb8518aff4530eL25-R28) [[2]](diffhunk://#diff-d603a75df5fa6c9be17834eebe92448943e16e0075dc4b18d4fb8518aff4530eR50)