### PR TITLE
[CA-633]feat: forbid raw icon and image usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.5.0 - Forbid Raw Icon and Image Usage (minor)
+
+### New Rule
+
+- **`forbid_raw_icon_and_image_usage`**: Forbids direct instantiation of `Icon(Icons.xxx)`
+  and `Image.asset()` in all Dart files except `coreui/lib/` and `coreui/test/`.
+  Use `CoreIcons` constants and coreui abstraction components instead.
+
+---
+
 ## 0.4.3 - restrict_core_icon_data Scope Fix (patch)
 
 ### Bug Fixes

--- a/bin/standalone_checker.dart
+++ b/bin/standalone_checker.dart
@@ -21,6 +21,7 @@ import 'package:ripplearc_linter/core/analyzers/forbid_helper_util_naming_analyz
 import 'package:ripplearc_linter/core/analyzers/prevent_feature_module_dependencies_analyzer.dart';
 import 'package:ripplearc_linter/core/analyzers/prevent_library_module_dependencies_analyzer.dart';
 import 'package:ripplearc_linter/core/analyzers/forbid_modular_get_outside_module_analyzer.dart';
+import 'package:ripplearc_linter/core/analyzers/forbid_raw_icon_and_image_usage_analyzer.dart';
 import 'package:ripplearc_linter/core/analyzers/restrict_core_icon_data_analyzer.dart';
 
 import 'package:path/path.dart' as p;
@@ -87,6 +88,7 @@ class StandaloneLintChecker {
       FeatureModuleIsolationAnalyzer(),
       LibraryModuleDependenciesAnalyzer(),
       ForbidModularGetOutsideModuleAnalyzer(),
+      ForbidRawIconAndImageUsageAnalyzer(),
       RestrictCoreIconDataAnalyzer(),
     ];
   }
@@ -108,6 +110,7 @@ class StandaloneLintChecker {
     'avoid_static_typography',
     'no_direct_instantiation',
     'forbid_helper_util_naming',
+    'forbid_raw_icon_and_image_usage',
     'restrict_core_icon_data',
   };
 
@@ -373,7 +376,7 @@ void main(List<String> args) async {
       'standalone_checker [--rules rule1,rule2] <files_or_directories> (after global activate)',
     );
     print(
-      'Available rules: avoid_static_typography, avoid_static_colors, forbid_forced_unwrapping, no_direct_instantiation, sealed_over_dynamic, private_subject, specific_exception_types, document_fake_parameters, document_interface, no_internal_method_docs, todo_with_story_links, no_optional_operators_in_tests, prefer_fake_over_mock, test_file_mutation_coverage , prevent_feature_module_dependencies, forbid_modular_get_outside_module, restrict_core_icon_data',
+      'Available rules: avoid_static_typography, avoid_static_colors, forbid_forced_unwrapping, no_direct_instantiation, sealed_over_dynamic, private_subject, specific_exception_types, document_fake_parameters, document_interface, no_internal_method_docs, todo_with_story_links, no_optional_operators_in_tests, prefer_fake_over_mock, test_file_mutation_coverage , prevent_feature_module_dependencies, forbid_modular_get_outside_module, forbid_raw_icon_and_image_usage, restrict_core_icon_data',
     );
     exit(1);
   }

--- a/docs/forbid_raw_icon_and_image_usage.md
+++ b/docs/forbid_raw_icon_and_image_usage.md
@@ -1,0 +1,54 @@
+# forbid_raw_icon_and_image_usage
+
+Forbids direct usage of raw Flutter `Icon(Icons.xxx)` and `Image.asset()` in application code. This rule enforces icon and image abstraction by requiring developers to use `CoreIcons` constants and coreui abstraction components, ensuring consistent visual styling and asset management across the codebase.
+
+## Bad ❌
+```dart
+import 'package:flutter/material.dart';
+
+class MyWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        // Direct Icon instantiation
+        Icon(Icons.home),  // LINT
+        Icon(Icons.import_contacts),  // LINT
+
+        // Direct Image.asset usage
+        Image.asset('assets/images/logo.png'),  // LINT
+      ],
+    );
+  }
+}
+```
+
+## Good ✅
+```dart
+class MyWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        // Use CoreIcons constants via coreui abstractions
+        CoreIcon(CoreIcons.home),
+        CoreIcon(CoreIcons.contacts),
+
+        // Use coreui abstraction components for images
+        CoreImage.asset(CoreAssets.logo),
+      ],
+    );
+  }
+}
+```
+
+## What's Detected
+- **Direct `Icon` instantiation**: `Icon(Icons.xxx)`
+- **Direct `Image.asset` usage**: both `Image.asset(...)` constructor invocations and method-style calls
+
+## Excluded Files
+- Files under `coreui/lib/` (coreui package implementation)
+- Files under `coreui/test/` (coreui package tests)
+
+## Known Limitations
+- `Icon()` detection is AST-name-only and does not filter by import source. The check `typeName == 'Icon'` flags any class named `Icon`, not strictly Flutter's `material.dart` `Icon`. This is a known limitation of unresolved-mode analysis shared by other rules in this repo (e.g., `restrict_core_icon_data`). In practice, collisions with non-Flutter `Icon` classes are rare in app code.

--- a/example/example_forbid_raw_icon_and_image_usage_rule.dart
+++ b/example/example_forbid_raw_icon_and_image_usage_rule.dart
@@ -1,0 +1,69 @@
+// ignore_for_file: unused_local_variable
+
+import 'package:flutter/material.dart';
+
+class CoreIcons {
+  static const home = 0;
+  static const contacts = 1;
+}
+
+// ============================================================================
+// ❌ VIOLATION EXAMPLES - These will trigger the linter
+// ============================================================================
+
+class ViolationExamples extends StatelessWidget {
+  const ViolationExamples({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        // ❌ VIOLATION: Direct Icon() usage with Icons.xxx
+        const Icon(Icons.home), // LINT
+
+        // ❌ VIOLATION: Direct Icon() with a different material icon
+        Icon(Icons.import_contacts), // LINT
+
+        // ❌ VIOLATION: Direct Image.asset() usage
+        Image.asset('assets/images/logo.png'), // LINT
+      ],
+    );
+  }
+}
+
+// ============================================================================
+// ✅ CORRECT EXAMPLES - These will NOT trigger the linter
+// ============================================================================
+
+class CoreIcon extends StatelessWidget {
+  final int icon;
+  const CoreIcon(this.icon, {super.key});
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+class CoreImage extends StatelessWidget {
+  const CoreImage.asset(String path, {super.key});
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+class CorrectExamples extends StatelessWidget {
+  const CorrectExamples({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: const [
+        // ✅ CORRECT: Use CoreIcons constants via coreui abstractions
+        CoreIcon(CoreIcons.home),
+        CoreIcon(CoreIcons.contacts),
+
+        // ✅ CORRECT: Use coreui abstraction components for images
+        CoreImage.asset('assets/images/logo.png'),
+      ],
+    );
+  }
+}

--- a/lib/core/analyzers/forbid_raw_icon_and_image_usage_analyzer.dart
+++ b/lib/core/analyzers/forbid_raw_icon_and_image_usage_analyzer.dart
@@ -70,8 +70,11 @@ class _ForbidRawIconAndImageUsageVisitor extends RecursiveAstVisitor<void> {
       );
     }
 
-    final importPrefix = constructorName.type.importPrefix?.name.lexeme;
-    if (importPrefix == 'Image' && typeName == 'asset') {
+    // Without type resolution, the parser treats `new Image.asset(...)` as a
+    // prefixed type: importPrefix='Image', name2='asset'. This is the correct
+    // way to detect the named constructor in an unresolved AST.
+    final classPrefix = constructorName.type.importPrefix?.name.lexeme;
+    if (classPrefix == 'Image' && typeName == 'asset') {
       issues.add(
         analyzer.createIssue(
           node,

--- a/lib/core/analyzers/forbid_raw_icon_and_image_usage_analyzer.dart
+++ b/lib/core/analyzers/forbid_raw_icon_and_image_usage_analyzer.dart
@@ -44,7 +44,8 @@ class ForbidRawIconAndImageUsageAnalyzer extends BaseAnalyzer {
   @override
   bool shouldSkipFile(String path) {
     final normalized = path.replaceAll('\\', '/');
-    return normalized.contains('/coreui/lib/') || normalized.contains('/coreui/test/');
+    return normalized.contains('/coreui/lib/') ||
+        normalized.contains('/coreui/test/');
   }
 }
 
@@ -67,19 +68,37 @@ class _ForbidRawIconAndImageUsageVisitor extends RecursiveAstVisitor<void> {
               'Direct usage of Icon() is restricted. Use CoreIcons and coreui components instead.',
         ),
       );
-    } else if (typeName == 'Image') {
-      final constructor = constructorName.name?.name;
-      if (constructor == 'asset') {
-        issues.add(
-          analyzer.createIssue(
-            node,
-            customMessage:
-                'Direct usage of Image.asset() is restricted. Use coreui components instead.',
-          ),
-        );
-      }
+    }
+
+    final importPrefix = constructorName.type.importPrefix?.name.lexeme;
+    if (importPrefix == 'Image' && typeName == 'asset') {
+      issues.add(
+        analyzer.createIssue(
+          node,
+          customMessage:
+              'Direct usage of Image.asset() is restricted. Use coreui components instead.',
+        ),
+      );
     }
 
     super.visitInstanceCreationExpression(node);
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    final target = node.target;
+    if (target is SimpleIdentifier &&
+        target.name == 'Image' &&
+        node.methodName.name == 'asset') {
+      issues.add(
+        analyzer.createIssue(
+          node,
+          customMessage:
+              'Direct usage of Image.asset() is restricted. Use coreui components instead.',
+        ),
+      );
+    }
+
+    super.visitMethodInvocation(node);
   }
 }

--- a/lib/core/analyzers/forbid_raw_icon_and_image_usage_analyzer.dart
+++ b/lib/core/analyzers/forbid_raw_icon_and_image_usage_analyzer.dart
@@ -1,0 +1,85 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'base_analyzer.dart';
+import '../models/lint_issue.dart';
+
+/// Analyzer that prevents direct usage of raw Flutter icons and Image.asset.
+///
+/// This rule enforces icon abstraction by requiring developers to use the `CoreIcons`
+/// constants instead of directly instantiating `Icon` with `Icons.xxx` or using `Image.asset`.
+///
+/// Example of code that triggers this rule:
+/// ```dart
+/// final icon = Icon(Icons.import_contacts); // LINT
+/// final image = Image.asset('assets/image.png'); // LINT
+/// ```
+class ForbidRawIconAndImageUsageAnalyzer extends BaseAnalyzer {
+  @override
+  String get ruleName => 'forbid_raw_icon_and_image_usage';
+
+  @override
+  String get problemMessage =>
+      'Raw Flutter icons and direct Image.asset usages are restricted. Use CoreIcons and coreui components instead.';
+
+  @override
+  String get correctionMessage =>
+      'Use CoreIcons constants or properly abstracted coreui components.';
+
+  @override
+  List<LintIssue> analyze(CompilationUnit unit) {
+    return [];
+  }
+
+  @override
+  List<LintIssue> analyzeWithResolver(CompilationUnit unit, dynamic resolver) {
+    final path = resolver.path ?? '';
+    if (shouldSkipFile(path)) {
+      return [];
+    }
+    final visitor = _ForbidRawIconAndImageUsageVisitor(this);
+    unit.accept(visitor);
+    return visitor.issues;
+  }
+
+  @override
+  bool shouldSkipFile(String path) {
+    final normalized = path.replaceAll('\\', '/');
+    return normalized.contains('/coreui/lib/') || normalized.contains('/coreui/test/');
+  }
+}
+
+class _ForbidRawIconAndImageUsageVisitor extends RecursiveAstVisitor<void> {
+  final ForbidRawIconAndImageUsageAnalyzer analyzer;
+  final List<LintIssue> issues = [];
+
+  _ForbidRawIconAndImageUsageVisitor(this.analyzer);
+
+  @override
+  void visitInstanceCreationExpression(InstanceCreationExpression node) {
+    final constructorName = node.constructorName;
+    final typeName = constructorName.type.name2.lexeme;
+
+    if (typeName == 'Icon') {
+      issues.add(
+        analyzer.createIssue(
+          node,
+          customMessage:
+              'Direct usage of Icon() is restricted. Use CoreIcons and coreui components instead.',
+        ),
+      );
+    } else if (typeName == 'Image') {
+      final constructor = constructorName.name?.name;
+      if (constructor == 'asset') {
+        issues.add(
+          analyzer.createIssue(
+            node,
+            customMessage:
+                'Direct usage of Image.asset() is restricted. Use coreui components instead.',
+          ),
+        );
+      }
+    }
+
+    super.visitInstanceCreationExpression(node);
+  }
+}

--- a/lib/custom_lint_rules/forbid_raw_icon_and_image_usage.dart
+++ b/lib/custom_lint_rules/forbid_raw_icon_and_image_usage.dart
@@ -2,6 +2,10 @@ import '../core/base_lint_rule.dart';
 import '../core/analyzers/forbid_raw_icon_and_image_usage_analyzer.dart';
 import '../core/analyzers/base_analyzer.dart';
 
+/// Lint rule that forbids direct usage of raw Flutter icons and [Image.asset].
+///
+/// Consumers must use [CoreIcons] constants and coreui abstraction components
+/// instead. See [ForbidRawIconAndImageUsageAnalyzer] for detection logic.
 class ForbidRawIconAndImageUsage extends BaseLintRule {
   ForbidRawIconAndImageUsage()
     : super(BaseLintRule.createLintCode(_analyzer), includeTests: true);

--- a/lib/custom_lint_rules/forbid_raw_icon_and_image_usage.dart
+++ b/lib/custom_lint_rules/forbid_raw_icon_and_image_usage.dart
@@ -1,0 +1,13 @@
+import '../core/base_lint_rule.dart';
+import '../core/analyzers/forbid_raw_icon_and_image_usage_analyzer.dart';
+import '../core/analyzers/base_analyzer.dart';
+
+class ForbidRawIconAndImageUsage extends BaseLintRule {
+  ForbidRawIconAndImageUsage()
+    : super(BaseLintRule.createLintCode(_analyzer), includeTests: true);
+
+  static final _analyzer = ForbidRawIconAndImageUsageAnalyzer();
+
+  @override
+  BaseAnalyzer get analyzer => _analyzer;
+}

--- a/lib/ripplearc_linter.dart
+++ b/lib/ripplearc_linter.dart
@@ -21,6 +21,7 @@ import 'custom_lint_rules/test_file_mutation_coverage.dart';
 import 'custom_lint_rules/prevent_feature_module_dependencies.dart';
 import 'custom_lint_rules/prevent_library_module_dependencies.dart';
 import 'custom_lint_rules/restrict_core_icon_data.dart';
+import 'custom_lint_rules/forbid_raw_icon_and_image_usage.dart';
 
 PluginBase createPlugin() => _RipplearcLintRules();
 
@@ -49,5 +50,6 @@ class _RipplearcLintRules extends PluginBase {
     PreventFeatureModuleDependencies(),
     PreventLibraryModuleDependencies(),
     RestrictCoreIconData(),
+    ForbidRawIconAndImageUsage(),
   ];
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ripplearc_linter
 description: A custom lint library following best engineering practice 
-version: 0.4.3
+version: 0.5.0
 repository: https://github.com/ripplearc/ripplearc-flutter-lint
 
 environment:

--- a/test/custom_lint_rules/forbid_raw_icon_and_image_usage_test.dart
+++ b/test/custom_lint_rules/forbid_raw_icon_and_image_usage_test.dart
@@ -1,0 +1,399 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:ripplearc_linter/custom_lint_rules/forbid_raw_icon_and_image_usage.dart';
+import 'package:ripplearc_linter/core/analyzers/forbid_raw_icon_and_image_usage_analyzer.dart';
+import 'package:test/test.dart';
+import '../utils/custom_lint_resolver.dart';
+import '../utils/test_error_reporter.dart';
+
+void main() {
+  group('ForbidRawIconAndImageUsage', () {
+    late ForbidRawIconAndImageUsage rule;
+    late TestErrorReporter reporter;
+    late CompilationUnit unit;
+
+    setUp(() {
+      rule = ForbidRawIconAndImageUsage();
+    });
+
+    Future<void> analyzeCode(String sourceCode, {required String path}) async {
+      reporter = TestErrorReporter();
+      final parseResult = parseString(content: sourceCode);
+      unit = parseResult.unit;
+      rule.run(
+        TestCustomLintResolver(unit, path: path),
+        reporter,
+        TestCustomLintContext(unit),
+      );
+    }
+
+    group('Icon() usage', () {
+      test('should flag Icon() constructor in app code', () async {
+        const source = '''
+        class Icons {
+          static const home = 1;
+        }
+        class Icon {
+          const Icon(dynamic iconData);
+        }
+        class MyWidget {
+          void build() {
+            final icon = new Icon(Icons.home);
+          }
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/widgets/my_widget.dart');
+        expect(reporter.errors, hasLength(1));
+      });
+
+      test('should flag Icon() constructor in test files', () async {
+        const source = '''
+        class Icons {
+          static const home = 1;
+        }
+        class Icon {
+          const Icon(dynamic iconData);
+        }
+        void main() {
+          test('example', () {
+            final icon = new Icon(Icons.home);
+          });
+        }
+        ''';
+        await analyzeCode(source, path: 'test/widgets/my_widget_test.dart');
+        expect(reporter.errors, hasLength(1));
+      });
+
+      test('should flag const Icon() usage', () async {
+        const source = '''
+        class Icons {
+          static const star = 1;
+        }
+        class Icon {
+          const Icon(dynamic iconData);
+        }
+        class MyWidget {
+          static const icon = const Icon(Icons.star);
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/widgets/my_widget.dart');
+        expect(reporter.errors, hasLength(1));
+      });
+
+      test('should flag multiple Icon() usages', () async {
+        const source = '''
+        class Icons {
+          static const home = 1;
+          static const star = 2;
+        }
+        class Icon {
+          const Icon(dynamic iconData);
+        }
+        class MyWidget {
+          void build() {
+            final icon1 = new Icon(Icons.home);
+            final icon2 = new Icon(Icons.star);
+          }
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/widgets/my_widget.dart');
+        expect(reporter.errors, hasLength(2));
+      });
+
+      test('should not flag Icon() in coreui/lib path', () async {
+        const source = '''
+        class Icons {
+          static const home = 1;
+        }
+        class Icon {
+          const Icon(dynamic iconData);
+        }
+        class CoreIconWidget {
+          void build() {
+            final icon = new Icon(Icons.home);
+          }
+        }
+        ''';
+        await analyzeCode(
+          source,
+          path: 'packages/coreui/lib/src/components/core_icon.dart',
+        );
+        expect(reporter.errors, isEmpty);
+      });
+
+      test('should not flag Icon() in coreui/test path', () async {
+        const source = '''
+        class Icons {
+          static const home = 1;
+        }
+        class Icon {
+          const Icon(dynamic iconData);
+        }
+        void main() {
+          test('example', () {
+            final icon = new Icon(Icons.home);
+          });
+        }
+        ''';
+        await analyzeCode(
+          source,
+          path: 'packages/coreui/test/components/core_icon_test.dart',
+        );
+        expect(reporter.errors, isEmpty);
+      });
+    });
+
+    group('Image.asset() path exclusion', () {
+      test('should not flag Image constructors in coreui/lib path', () async {
+        const source = '''
+        class Image {
+          Image.asset(String name);
+          Image.network(String url);
+        }
+        class CoreImageWidget {
+          void build() {
+            final image = new Image.asset('assets/image.png');
+            final network = new Image.network('https://example.com');
+          }
+        }
+        ''';
+        await analyzeCode(
+          source,
+          path: 'packages/coreui/lib/src/components/core_image.dart',
+        );
+        expect(reporter.errors, isEmpty);
+      });
+
+      test('should not flag Image constructors in coreui/test path', () async {
+        const source = '''
+        class Image {
+          Image.asset(String name);
+        }
+        void main() {
+          test('example', () {
+            final image = new Image.asset('assets/image.png');
+          });
+        }
+        ''';
+        await analyzeCode(
+          source,
+          path: 'packages/coreui/test/components/core_image_test.dart',
+        );
+        expect(reporter.errors, isEmpty);
+      });
+    });
+
+    group('shouldSkipFile', () {
+      late ForbidRawIconAndImageUsageAnalyzer analyzer;
+
+      setUp(() {
+        analyzer = ForbidRawIconAndImageUsageAnalyzer();
+      });
+
+      test('should skip files in coreui/lib/', () {
+        expect(
+          analyzer.shouldSkipFile(
+            'packages/coreui/lib/src/components/core_icon.dart',
+          ),
+          isTrue,
+        );
+      });
+
+      test('should skip files in coreui/test/', () {
+        expect(
+          analyzer.shouldSkipFile(
+            'packages/coreui/test/components/core_icon_test.dart',
+          ),
+          isTrue,
+        );
+      });
+
+      test('should not skip app lib files', () {
+        expect(analyzer.shouldSkipFile('lib/widgets/my_widget.dart'), isFalse);
+      });
+
+      test('should not skip app test files', () {
+        expect(
+          analyzer.shouldSkipFile('test/widgets/my_widget_test.dart'),
+          isFalse,
+        );
+      });
+
+      test('should handle Windows-style paths', () {
+        expect(
+          analyzer.shouldSkipFile(
+            r'packages\coreui\lib\src\components\core_icon.dart',
+          ),
+          isTrue,
+        );
+        expect(
+          analyzer.shouldSkipFile(
+            r'packages\coreui\test\components\core_icon_test.dart',
+          ),
+          isTrue,
+        );
+      });
+    });
+
+    group('edge cases', () {
+      test('should not flag unrelated classes', () async {
+        const source = '''
+        class CustomIcon {
+          const CustomIcon(dynamic data);
+        }
+        class MyWidget {
+          void build() {
+            final icon = new CustomIcon('data');
+          }
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/widgets/my_widget.dart');
+        expect(reporter.errors, isEmpty);
+      });
+
+      test(
+        'should not flag CoreIcons usage (the approved replacement)',
+        () async {
+          const source = '''
+        class CoreIcons {
+          static const arrowRight = 'icon_data';
+        }
+        class MyWidget {
+          void build() {
+            final icon = CoreIcons.arrowRight;
+          }
+        }
+        ''';
+          await analyzeCode(source, path: 'lib/widgets/my_widget.dart');
+          expect(reporter.errors, isEmpty);
+        },
+      );
+
+      test('should handle empty source code', () async {
+        const source = '';
+        await analyzeCode(source, path: 'lib/widgets/empty.dart');
+        expect(reporter.errors, isEmpty);
+      });
+
+      test('should handle source with no violations', () async {
+        const source = '''
+        class MyWidget {
+          void build() {
+            print('no icons here');
+          }
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/widgets/my_widget.dart');
+        expect(reporter.errors, isEmpty);
+      });
+    });
+
+    group('rule metadata', () {
+      test('rule name', () {
+        expect(rule.code.name, equals('forbid_raw_icon_and_image_usage'));
+      });
+
+      test('problem message mentions raw icons and Image.asset', () {
+        expect(rule.code.problemMessage, contains('Raw Flutter icons'));
+        expect(rule.code.problemMessage, contains('Image.asset'));
+      });
+
+      test('rule includes test files', () {
+        expect(
+          ForbidRawIconAndImageUsageAnalyzer().shouldSkipFile(
+            'test/my_test.dart',
+          ),
+          isFalse,
+        );
+      });
+    });
+
+    group('analyzer interface', () {
+      test('analyze() returns empty list (bypass check)', () {
+        const source = '''
+        class Icon {
+          const Icon(dynamic iconData);
+        }
+        class Icons {
+          static const home = 1;
+        }
+        void f() { new Icon(Icons.home); }
+        ''';
+        final parseResult = parseString(content: source);
+        final unit = parseResult.unit;
+
+        final issues = rule.analyzer.analyze(unit);
+        expect(
+          issues,
+          isEmpty,
+          reason:
+              'analyze() should return an empty list to prevent path-unaware analysis',
+        );
+      });
+
+      test(
+        'analyzeWithResolver returns issues for Icon() on non-excluded path',
+        () {
+          const source = '''
+        class Icon {
+          const Icon(dynamic iconData);
+        }
+        class Icons {
+          static const home = 1;
+        }
+        void f() { new Icon(Icons.home); }
+        ''';
+          final parseResult = parseString(content: source);
+          final unit = parseResult.unit;
+          final resolver = TestCustomLintResolver(unit, path: 'lib/main.dart');
+
+          final issues = rule.analyzer.analyzeWithResolver(unit, resolver);
+          expect(issues, hasLength(1));
+          expect(
+            issues.first.ruleName,
+            equals('forbid_raw_icon_and_image_usage'),
+          );
+          expect(issues.first.message, contains('Icon()'));
+        },
+      );
+
+      test('analyzeWithResolver returns empty for excluded coreui path', () {
+        const source = '''
+        class Icon {
+          const Icon(dynamic iconData);
+        }
+        class Icons {
+          static const home = 1;
+        }
+        void f() { new Icon(Icons.home); }
+        ''';
+        final parseResult = parseString(content: source);
+        final unit = parseResult.unit;
+        final resolver = TestCustomLintResolver(
+          unit,
+          path: 'packages/coreui/lib/src/core_icon.dart',
+        );
+
+        final issues = rule.analyzer.analyzeWithResolver(unit, resolver);
+        expect(issues, isEmpty);
+      });
+
+      test('analyzer exposes correct rule name', () {
+        expect(
+          rule.analyzer.ruleName,
+          equals('forbid_raw_icon_and_image_usage'),
+        );
+      });
+
+      test('analyzer exposes problem message', () {
+        expect(rule.analyzer.problemMessage, isNotEmpty);
+        expect(rule.analyzer.problemMessage, contains('Raw Flutter icons'));
+      });
+
+      test('analyzer exposes correction message', () {
+        expect(rule.analyzer.correctionMessage, isNotEmpty);
+        expect(rule.analyzer.correctionMessage, contains('CoreIcons'));
+      });
+    });
+  });
+}

--- a/test/custom_lint_rules/forbid_raw_icon_and_image_usage_test.dart
+++ b/test/custom_lint_rules/forbid_raw_icon_and_image_usage_test.dart
@@ -143,7 +143,106 @@ void main() {
       });
     });
 
-    group('Image.asset() path exclusion', () {
+    group('Image.asset() usage', () {
+      test('should flag Image.asset() in app code', () async {
+        const source = '''
+        class Image {
+          Image.asset(String name);
+        }
+        class MyWidget {
+          void build() {
+            final image = new Image.asset('assets/image.png');
+          }
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/widgets/my_widget.dart');
+        expect(reporter.errors, hasLength(1));
+      });
+
+      test('should flag Image.asset() in test files', () async {
+        const source = '''
+        class Image {
+          Image.asset(String name);
+        }
+        void main() {
+          test('example', () {
+            final image = new Image.asset('assets/logo.png');
+          });
+        }
+        ''';
+        await analyzeCode(source, path: 'test/widgets/my_widget_test.dart');
+        expect(reporter.errors, hasLength(1));
+      });
+
+      test('should flag multiple Image.asset() usages', () async {
+        const source = '''
+        class Image {
+          Image.asset(String name);
+        }
+        class MyWidget {
+          void build() {
+            final img1 = new Image.asset('assets/image1.png');
+            final img2 = new Image.asset('assets/image2.png');
+          }
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/widgets/my_widget.dart');
+        expect(reporter.errors, hasLength(2));
+      });
+
+      test('should not flag Image.network() (only Image.asset is restricted)',
+          () async {
+        const source = '''
+        class Image {
+          Image.network(String url);
+        }
+        class MyWidget {
+          void build() {
+            final image = new Image.network('https://example.com/img.png');
+          }
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/widgets/my_widget.dart');
+        expect(reporter.errors, isEmpty);
+      });
+
+      test('should not flag plain Image() default constructor', () async {
+        const source = '''
+        class Image {
+          Image();
+        }
+        class MyWidget {
+          void build() {
+            final image = new Image();
+          }
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/widgets/my_widget.dart');
+        expect(reporter.errors, isEmpty);
+      });
+
+      test('should flag both Icon() and Image.asset() in same file', () async {
+        const source = '''
+        class Icons {
+          static const home = 1;
+        }
+        class Icon {
+          const Icon(dynamic iconData);
+        }
+        class Image {
+          Image.asset(String name);
+        }
+        class MyWidget {
+          void build() {
+            final icon = new Icon(Icons.home);
+            final image = new Image.asset('assets/image.png');
+          }
+        }
+        ''';
+        await analyzeCode(source, path: 'lib/widgets/my_widget.dart');
+        expect(reporter.errors, hasLength(2));
+      });
+
       test('should not flag Image constructors in coreui/lib path', () async {
         const source = '''
         class Image {

--- a/test/standalone_checker_test.dart
+++ b/test/standalone_checker_test.dart
@@ -22,10 +22,10 @@ void main() {
     });
 
     group('Bridge Initialization and Configuration', () {
-      test('should initialize with all 19 custom lint analyzers', () {
+      test('should initialize with all 20 custom lint analyzers', () {
         final checker = StandaloneLintChecker();
 
-        expect(checker.analyzers.length, equals(19));
+        expect(checker.analyzers.length, equals(20));
 
         final ruleNames = checker.analyzers.map((a) => a.ruleName).toSet();
         final expectedRules = {

--- a/test/standalone_checker_test.dart
+++ b/test/standalone_checker_test.dart
@@ -47,6 +47,7 @@ void main() {
           'feature_module_isolation',
           'prevent_library_module_dependencies',
           'forbid_modular_get_outside_module',
+          'forbid_raw_icon_and_image_usage',
           'restrict_core_icon_data',
         };
 


### PR DESCRIPTION
This pull request introduces a new lint rule to prevent direct usage of raw Flutter icons and `Image.asset`, encouraging the use of abstraction layers like `CoreIcons` and coreui components. The rule is implemented, registered, and tested within the linter framework, increasing the total custom lint analyzers to 19.

**New lint rule: Forbid raw icon and image usage**
- Added `ForbidRawIconAndImageUsageAnalyzer`, which flags direct instantiations of `Icon` with `Icons.xxx` and `Image.asset`, except in coreui library and test files.
- Created the corresponding lint rule class `ForbidRawIconAndImageUsage` to wire the analyzer into the linting framework.

**Linter integration**
- Registered the new lint rule in the main plugin (`_RipplearcLintRules`) so it is applied during analysis. [[1]](diffhunk://#diff-b288bac189a1395f7465f1b3755548002ced8c289b7f3eb04c273b7b6548c515R24) [[2]](diffhunk://#diff-b288bac189a1395f7465f1b3755548002ced8c289b7f3eb04c273b7b6548c515R53)

**Testing and validation**
- Updated the analyzer count in tests to reflect the addition of the new lint rule, ensuring test coverage and correctness.