### PR TITLE
[CA-912] feat: add forbid_manual_screenshot_theme lint rule

### DIFF
--- a/bin/standalone_checker.dart
+++ b/bin/standalone_checker.dart
@@ -23,6 +23,7 @@ import 'package:ripplearc_linter/core/analyzers/prevent_library_module_dependenc
 import 'package:ripplearc_linter/core/analyzers/forbid_modular_get_outside_module_analyzer.dart';
 import 'package:ripplearc_linter/core/analyzers/forbid_raw_icon_and_image_usage_analyzer.dart';
 import 'package:ripplearc_linter/core/analyzers/restrict_core_icon_data_analyzer.dart';
+import 'package:ripplearc_linter/core/analyzers/forbid_manual_screenshot_theme_analyzer.dart';
 
 import 'package:path/path.dart' as p;
 import 'package:analyzer/dart/analysis/utilities.dart';
@@ -90,6 +91,7 @@ class StandaloneLintChecker {
       ForbidModularGetOutsideModuleAnalyzer(),
       ForbidRawIconAndImageUsageAnalyzer(),
       RestrictCoreIconDataAnalyzer(),
+      ForbidManualScreenshotThemeAnalyzer(),
     ];
   }
 
@@ -103,6 +105,7 @@ class StandaloneLintChecker {
     'prefer_fake_over_mock',
     'document_fake_parameters',
     'test_file_mutation_coverage',
+    'forbid_manual_screenshot_theme',
   };
 
   static const Set<String> _bothFilesRuleNames = {
@@ -376,7 +379,7 @@ void main(List<String> args) async {
       'standalone_checker [--rules rule1,rule2] <files_or_directories> (after global activate)',
     );
     print(
-      'Available rules: avoid_static_typography, avoid_static_colors, forbid_forced_unwrapping, no_direct_instantiation, sealed_over_dynamic, private_subject, specific_exception_types, document_fake_parameters, document_interface, no_internal_method_docs, todo_with_story_links, no_optional_operators_in_tests, prefer_fake_over_mock, test_file_mutation_coverage , prevent_feature_module_dependencies, forbid_modular_get_outside_module, forbid_raw_icon_and_image_usage, restrict_core_icon_data',
+      'Available rules: avoid_static_typography, avoid_static_colors, forbid_forced_unwrapping, no_direct_instantiation, sealed_over_dynamic, private_subject, specific_exception_types, document_fake_parameters, document_interface, no_internal_method_docs, todo_with_story_links, no_optional_operators_in_tests, prefer_fake_over_mock, test_file_mutation_coverage, prevent_feature_module_dependencies, forbid_modular_get_outside_module, forbid_raw_icon_and_image_usage, restrict_core_icon_data, forbid_manual_screenshot_theme',
     );
     exit(1);
   }

--- a/docs/forbid_manual_screenshot_theme.md
+++ b/docs/forbid_manual_screenshot_theme.md
@@ -1,0 +1,65 @@
+# forbid_manual_screenshot_theme
+
+Forbids the manual dual-theme pattern in `*_screenshot_test.dart` files.
+
+CA-847 introduced `screenshotThemeGroups` to replace two fragile patterns that
+had to be repeated manually across screenshot tests:
+
+1. A nullable `ThemeData?` pump-helper parameter — it collides with the
+   `no_optional_operators_in_tests` lint rule and forces an `if/else` workaround.
+2. A hand-typed `_dark.png` suffix in every `matchesGoldenFile` call — easy to
+   forget or mistype.
+
+Use `screenshotThemeGroups` instead; it handles both automatically.
+
+**Scope:** only fires in files whose name ends with `_screenshot_test.dart`.
+Existing files that intentionally use the old pattern can suppress with
+`// ignore_for_file: forbid_manual_screenshot_theme`.
+
+## Bad ❌
+
+```dart
+// my_widget_screenshot_test.dart
+
+// ThemeData? parameter — manual theme switching
+Future<void> _pumpMyWidget(
+  WidgetTester tester,
+  ThemeData? theme,       // LINT
+) async {
+  await tester.pumpWidget(
+    Theme(data: theme ?? ThemeData.light(), child: const MyWidget()),
+  );
+}
+
+// Hard-coded _dark.png suffix — manual golden naming
+void main() {
+  testWidgets('dark theme golden', (tester) async {
+    await _pumpMyWidget(tester, ThemeData.dark());
+    await expectLater(
+      find.byType(MyWidget),
+      matchesGoldenFile('goldens/my_widget_dark.png'), // LINT
+    );
+  });
+}
+```
+
+## Good ✅
+
+```dart
+// my_widget_screenshot_test.dart
+
+// Use screenshotThemeGroups — no ThemeData? param, no _dark.png suffix
+Future<void> _pumpMyWidget(WidgetTester tester) async {
+  await tester.pumpWidget(const MyWidget());
+}
+
+void main() {
+  screenshotThemeGroups('MyWidget', (tester, goldenSuffix) async {
+    await _pumpMyWidget(tester);
+    await expectLater(
+      find.byType(MyWidget),
+      matchesGoldenFile('goldens/my_widget$goldenSuffix'),
+    );
+  });
+}
+```

--- a/example/example_forbid_manual_screenshot_theme_rule.dart
+++ b/example/example_forbid_manual_screenshot_theme_rule.dart
@@ -1,0 +1,39 @@
+// ignore_for_file: unused_element, unused_local_variable
+
+// Simulated stubs so the example compiles standalone.
+class ThemeData {
+  const ThemeData();
+  static ThemeData light() => const ThemeData();
+  static ThemeData dark() => const ThemeData();
+}
+
+class WidgetTester {}
+
+class MyWidget {}
+
+dynamic get finder => null;
+
+dynamic matchesGoldenFile(String path) => null;
+
+// ─── BAD: manual dual-theme pattern ──────────────────────────────────────────
+
+// LINT — ThemeData? nullable parameter in a screenshot test helper
+Future<void> _pumpMyWidget(WidgetTester tester, ThemeData? theme) async {}
+
+void badExamples() {
+  // LINT — hard-coded _dark.png suffix passed directly to matchesGoldenFile
+  matchesGoldenFile('goldens/my_widget_dark.png');
+}
+
+// ─── GOOD: use screenshotThemeGroups ─────────────────────────────────────────
+
+// OK — no ThemeData? parameter
+Future<void> _pumpMyWidgetCorrect(WidgetTester tester) async {}
+
+void goodExamples(String goldenSuffix) {
+  // OK — suffix comes from the goldenSuffix parameter supplied by screenshotThemeGroups
+  matchesGoldenFile('goldens/my_widget$goldenSuffix');
+
+  // OK — non-dark suffix literal
+  matchesGoldenFile('goldens/my_widget_light.png');
+}

--- a/lib/core/analyzers/forbid_manual_screenshot_theme_analyzer.dart
+++ b/lib/core/analyzers/forbid_manual_screenshot_theme_analyzer.dart
@@ -3,6 +3,8 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'base_analyzer.dart';
 import '../models/lint_issue.dart';
 
+/// Flags manual dual-theme patterns (`ThemeData?` params, `_dark.png`
+/// golden suffixes) in `*_screenshot_test.dart` files.
 class ForbidManualScreenshotThemeAnalyzer extends BaseAnalyzer {
   @override
   String get ruleName => 'forbid_manual_screenshot_theme';

--- a/lib/core/analyzers/forbid_manual_screenshot_theme_analyzer.dart
+++ b/lib/core/analyzers/forbid_manual_screenshot_theme_analyzer.dart
@@ -1,0 +1,84 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'base_analyzer.dart';
+import '../models/lint_issue.dart';
+
+class ForbidManualScreenshotThemeAnalyzer extends BaseAnalyzer {
+  @override
+  String get ruleName => 'forbid_manual_screenshot_theme';
+
+  @override
+  String get problemMessage =>
+      'Manual dual-theme pattern detected. Use screenshotThemeGroups instead.';
+
+  @override
+  String get correctionMessage =>
+      'Replace manual ThemeData? parameters and _dark.png suffixes with screenshotThemeGroups.';
+
+  @override
+  List<LintIssue> analyze(CompilationUnit unit) {
+    // Intentionally returns [] — path context is required.
+    // Any caller that bypasses analyzeWithResolver gets no violations
+    // rather than false positives on non-screenshot files.
+    return [];
+  }
+
+  @override
+  List<LintIssue> analyzeWithResolver(CompilationUnit unit, dynamic resolver) {
+    final path = resolver.path as String? ?? '';
+    if (shouldSkipFile(path)) return [];
+    final visitor = _ForbidManualScreenshotThemeVisitor(this);
+    unit.accept(visitor);
+    return visitor.issues;
+  }
+
+  @override
+  bool shouldSkipFile(String path) {
+    final basename = path.replaceAll('\\', '/').split('/').last;
+    return !basename.endsWith('_screenshot_test.dart');
+  }
+}
+
+class _ForbidManualScreenshotThemeVisitor extends RecursiveAstVisitor<void> {
+  final ForbidManualScreenshotThemeAnalyzer analyzer;
+  final List<LintIssue> issues = [];
+
+  _ForbidManualScreenshotThemeVisitor(this.analyzer);
+
+  @override
+  void visitSimpleFormalParameter(SimpleFormalParameter node) {
+    final type = node.type;
+    if (type is NamedType &&
+        type.name2.lexeme == 'ThemeData' &&
+        type.question != null) {
+      issues.add(
+        analyzer.createIssue(
+          node,
+          customMessage:
+              'ThemeData? parameter found in screenshot test. Use screenshotThemeGroups to handle theme variants automatically.',
+        ),
+      );
+    }
+    super.visitSimpleFormalParameter(node);
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (node.methodName.name == 'matchesGoldenFile') {
+      final args = node.argumentList.arguments;
+      if (args.isNotEmpty && args.first is SimpleStringLiteral) {
+        final literal = args.first as SimpleStringLiteral;
+        if (literal.value.endsWith('_dark.png')) {
+          issues.add(
+            analyzer.createIssue(
+              literal,
+              customMessage:
+                  "Hard-coded '_dark.png' suffix in matchesGoldenFile. Use screenshotThemeGroups to generate golden suffixes automatically.",
+            ),
+          );
+        }
+      }
+    }
+    super.visitMethodInvocation(node);
+  }
+}

--- a/lib/custom_lint_rules/forbid_manual_screenshot_theme.dart
+++ b/lib/custom_lint_rules/forbid_manual_screenshot_theme.dart
@@ -1,0 +1,21 @@
+import '../core/base_lint_rule.dart';
+import '../core/analyzers/forbid_manual_screenshot_theme_analyzer.dart';
+import '../core/analyzers/base_analyzer.dart';
+
+/// Lint rule that forbids the manual dual-theme pattern in screenshot tests.
+///
+/// Flags [ThemeData?] nullable parameters and hard-coded `_dark.png` suffixes
+/// in `matchesGoldenFile` calls inside `*_screenshot_test.dart` files.
+/// Use `screenshotThemeGroups` instead. See [ForbidManualScreenshotThemeAnalyzer]
+/// for detection logic.
+class ForbidManualScreenshotTheme extends BaseLintRule {
+  ForbidManualScreenshotTheme()
+    : super(BaseLintRule.createLintCode(_analyzer), testOnly: true);
+  // testOnly: true so BaseLintRule.run() passes test files through to the
+  // analyzer; shouldSkipFile then narrows scope to *_screenshot_test.dart only.
+
+  static final _analyzer = ForbidManualScreenshotThemeAnalyzer();
+
+  @override
+  BaseAnalyzer get analyzer => _analyzer;
+}

--- a/lib/ripplearc_linter.dart
+++ b/lib/ripplearc_linter.dart
@@ -22,6 +22,7 @@ import 'custom_lint_rules/prevent_feature_module_dependencies.dart';
 import 'custom_lint_rules/prevent_library_module_dependencies.dart';
 import 'custom_lint_rules/restrict_core_icon_data.dart';
 import 'custom_lint_rules/forbid_raw_icon_and_image_usage.dart';
+import 'custom_lint_rules/forbid_manual_screenshot_theme.dart';
 
 PluginBase createPlugin() => _RipplearcLintRules();
 
@@ -51,5 +52,6 @@ class _RipplearcLintRules extends PluginBase {
     PreventLibraryModuleDependencies(),
     RestrictCoreIconData(),
     ForbidRawIconAndImageUsage(),
+    ForbidManualScreenshotTheme(),
   ];
 }

--- a/test/custom_lint_rules/forbid_manual_screenshot_theme_test.dart
+++ b/test/custom_lint_rules/forbid_manual_screenshot_theme_test.dart
@@ -1,0 +1,286 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:ripplearc_linter/custom_lint_rules/forbid_manual_screenshot_theme.dart';
+import 'package:ripplearc_linter/core/analyzers/forbid_manual_screenshot_theme_analyzer.dart';
+import 'package:test/test.dart';
+import '../utils/custom_lint_resolver.dart';
+import '../utils/test_error_reporter.dart';
+
+void main() {
+  group('ForbidManualScreenshotTheme', () {
+    late ForbidManualScreenshotTheme rule;
+    late TestErrorReporter reporter;
+    late CompilationUnit unit;
+
+    setUp(() {
+      rule = ForbidManualScreenshotTheme();
+    });
+
+    Future<void> analyzeCode(String sourceCode, {required String path}) async {
+      reporter = TestErrorReporter();
+      final parseResult = parseString(content: sourceCode);
+      unit = parseResult.unit;
+      rule.run(
+        TestCustomLintResolver(unit, path: path),
+        reporter,
+        TestCustomLintContext(unit),
+      );
+    }
+
+    group('ThemeData? parameter detection', () {
+      test('flags ThemeData? parameter in screenshot test file', () async {
+        const source = '''
+        void pumpWidget(WidgetTester tester, ThemeData? theme) async {}
+        ''';
+        await analyzeCode(source,
+            path: '/test/my_widget_screenshot_test.dart');
+        expect(reporter.errors, hasLength(1));
+      });
+
+      test('flags ThemeData? parameter on a method in screenshot test', () async {
+        const source = '''
+        class ScreenshotHelper {
+          Future<void> pump(ThemeData? theme) async {}
+        }
+        ''';
+        await analyzeCode(source,
+            path: '/test/home_screenshot_test.dart');
+        expect(reporter.errors, hasLength(1));
+      });
+
+      test('does not flag non-nullable ThemeData parameter', () async {
+        const source = '''
+        void pumpWidget(WidgetTester tester, ThemeData theme) async {}
+        ''';
+        await analyzeCode(source,
+            path: '/test/my_widget_screenshot_test.dart');
+        expect(reporter.errors, isEmpty);
+      });
+
+      test('does not flag other nullable parameters', () async {
+        const source = '''
+        void pumpWidget(WidgetTester tester, String? label) async {}
+        ''';
+        await analyzeCode(source,
+            path: '/test/my_widget_screenshot_test.dart');
+        expect(reporter.errors, isEmpty);
+      });
+    });
+
+    group('_dark.png suffix detection in matchesGoldenFile', () {
+      test('flags _dark.png suffix in matchesGoldenFile', () async {
+        const source = '''
+        void main() {
+          expect(finder, matchesGoldenFile('golden/my_widget_dark.png'));
+        }
+        ''';
+        await analyzeCode(source,
+            path: '/test/my_widget_screenshot_test.dart');
+        expect(reporter.errors, hasLength(1));
+      });
+
+      test('does not flag non-dark golden suffix', () async {
+        const source = '''
+        void main() {
+          expect(finder, matchesGoldenFile('golden/my_widget_light.png'));
+        }
+        ''';
+        await analyzeCode(source,
+            path: '/test/my_widget_screenshot_test.dart');
+        expect(reporter.errors, isEmpty);
+      });
+
+      test('does not flag matchesGoldenFile without string literal argument',
+          () async {
+        const source = '''
+        void main() {
+          final path = getPath();
+          expect(finder, matchesGoldenFile(path));
+        }
+        ''';
+        await analyzeCode(source,
+            path: '/test/my_widget_screenshot_test.dart');
+        expect(reporter.errors, isEmpty);
+      });
+
+      test('does not flag string ending in _dark.png outside matchesGoldenFile',
+          () async {
+        const source = '''
+        void main() {
+          final label = 'golden_dark.png';
+        }
+        ''';
+        await analyzeCode(source,
+            path: '/test/my_widget_screenshot_test.dart');
+        expect(reporter.errors, isEmpty);
+      });
+    });
+
+    group('combined violations', () {
+      test('flags both ThemeData? and _dark.png in same file', () async {
+        const source = '''
+        Future<void> pump(WidgetTester tester, ThemeData? theme) async {}
+        void main() {
+          expect(finder, matchesGoldenFile('golden/widget_dark.png'));
+        }
+        ''';
+        await analyzeCode(source,
+            path: '/test/my_widget_screenshot_test.dart');
+        expect(reporter.errors, hasLength(2));
+      });
+
+      test('flags multiple ThemeData? parameters', () async {
+        const source = '''
+        void pumpLight(ThemeData? theme) async {}
+        void pumpDark(ThemeData? theme) async {}
+        ''';
+        await analyzeCode(source,
+            path: '/test/my_widget_screenshot_test.dart');
+        expect(reporter.errors, hasLength(2));
+      });
+    });
+
+    group('path filtering (shouldSkipFile)', () {
+      test('does not flag violations in non-screenshot test files', () async {
+        const source = '''
+        Future<void> pump(WidgetTester tester, ThemeData? theme) async {}
+        void main() {
+          expect(finder, matchesGoldenFile('golden/widget_dark.png'));
+        }
+        ''';
+        await analyzeCode(source, path: '/test/my_widget_test.dart');
+        expect(reporter.errors, isEmpty);
+      });
+
+      test('does not flag violations in production files', () async {
+        const source = '''
+        void doSomething(ThemeData? theme) {}
+        ''';
+        await analyzeCode(source, path: '/lib/my_widget.dart');
+        expect(reporter.errors, isEmpty);
+      });
+
+      test('does not flag violations in generated files', () async {
+        const source = '''
+        void doSomething(ThemeData? theme) {}
+        ''';
+        await analyzeCode(source, path: '/lib/my_widget.g.dart');
+        expect(reporter.errors, isEmpty);
+      });
+
+      test('flags violations when filename ends with _screenshot_test.dart',
+          () async {
+        const source = '''
+        void pump(ThemeData? theme) async {}
+        ''';
+        await analyzeCode(source,
+            path: '/test/deep/nested/feature_screenshot_test.dart');
+        expect(reporter.errors, hasLength(1));
+      });
+    });
+
+    group('shouldSkipFile', () {
+      late ForbidManualScreenshotThemeAnalyzer analyzer;
+
+      setUp(() {
+        analyzer = ForbidManualScreenshotThemeAnalyzer();
+      });
+
+      test('skips non-screenshot test files', () {
+        expect(analyzer.shouldSkipFile('/test/my_widget_test.dart'), isTrue);
+      });
+
+      test('skips production lib files', () {
+        expect(analyzer.shouldSkipFile('/lib/my_widget.dart'), isTrue);
+      });
+
+      test('skips generated files', () {
+        expect(analyzer.shouldSkipFile('/lib/my_widget.g.dart'), isTrue);
+        expect(
+            analyzer.shouldSkipFile('/lib/my_widget.freezed.dart'), isTrue);
+      });
+
+      test('does not skip screenshot test files', () {
+        expect(
+            analyzer.shouldSkipFile('/test/my_widget_screenshot_test.dart'),
+            isFalse);
+      });
+
+      test('handles Windows-style paths', () {
+        expect(
+          analyzer.shouldSkipFile(
+              r'test\my_widget_screenshot_test.dart'),
+          isFalse,
+        );
+        expect(
+          analyzer.shouldSkipFile(r'test\my_widget_test.dart'),
+          isTrue,
+        );
+      });
+    });
+
+    group('rule metadata', () {
+      test('rule name', () {
+        expect(rule.code.name, equals('forbid_manual_screenshot_theme'));
+      });
+
+      test('problem message mentions screenshotThemeGroups', () {
+        expect(
+            rule.code.problemMessage, contains('screenshotThemeGroups'));
+      });
+    });
+
+    group('direct analyze() call', () {
+      test('analyze() returns empty list (path context guard)', () {
+        const source = '''
+        Future<void> pump(ThemeData? theme) async {}
+        ''';
+        final parseResult = parseString(content: source);
+        final testUnit = parseResult.unit;
+
+        final issues = rule.analyzer.analyze(testUnit);
+        expect(
+          issues,
+          isEmpty,
+          reason:
+              'analyze() must return [] — path context is required to avoid false positives on non-screenshot files',
+        );
+      });
+    });
+
+    group('analyzer interface', () {
+      test('analyzeWithResolver flags violations on screenshot test path',
+          () {
+        const source = '''
+        void pump(ThemeData? theme) async {}
+        ''';
+        final parseResult = parseString(content: source);
+        final testUnit = parseResult.unit;
+        final resolver = TestCustomLintResolver(
+          testUnit,
+          path: '/test/my_widget_screenshot_test.dart',
+        );
+
+        final issues = rule.analyzer.analyzeWithResolver(testUnit, resolver);
+        expect(issues, hasLength(1));
+        expect(issues.first.ruleName,
+            equals('forbid_manual_screenshot_theme'));
+      });
+
+      test('analyzeWithResolver returns empty for non-screenshot path', () {
+        const source = '''
+        void pump(ThemeData? theme) async {}
+        ''';
+        final parseResult = parseString(content: source);
+        final testUnit = parseResult.unit;
+        final resolver = TestCustomLintResolver(
+          testUnit,
+          path: '/test/my_widget_test.dart',
+        );
+
+        final issues = rule.analyzer.analyzeWithResolver(testUnit, resolver);
+        expect(issues, isEmpty);
+      });
+    });
+  });
+}

--- a/test/custom_lint_rules/forbid_manual_screenshot_theme_test.dart
+++ b/test/custom_lint_rules/forbid_manual_screenshot_theme_test.dart
@@ -65,6 +65,16 @@ void main() {
             path: '/test/my_widget_screenshot_test.dart');
         expect(reporter.errors, isEmpty);
       });
+
+      test('does not flag a type that merely contains "ThemeData" as a substring',
+          () async {
+        const source = '''
+        void pumpWidget(WidgetTester tester, AppThemeData? theme) async {}
+        ''';
+        await analyzeCode(source,
+            path: '/test/my_widget_screenshot_test.dart');
+        expect(reporter.errors, isEmpty);
+      });
     });
 
     group('_dark.png suffix detection in matchesGoldenFile', () {

--- a/test/standalone_checker_test.dart
+++ b/test/standalone_checker_test.dart
@@ -22,10 +22,10 @@ void main() {
     });
 
     group('Bridge Initialization and Configuration', () {
-      test('should initialize with all 20 custom lint analyzers', () {
+      test('should initialize with all 21 custom lint analyzers', () {
         final checker = StandaloneLintChecker();
 
-        expect(checker.analyzers.length, equals(20));
+        expect(checker.analyzers.length, equals(21));
 
         final ruleNames = checker.analyzers.map((a) => a.ruleName).toSet();
         final expectedRules = {
@@ -49,6 +49,7 @@ void main() {
           'forbid_modular_get_outside_module',
           'forbid_raw_icon_and_image_usage',
           'restrict_core_icon_data',
+          'forbid_manual_screenshot_theme',
         };
 
         expect(ruleNames, equals(expectedRules));


### PR DESCRIPTION
### 1. PR SUMMARY

Adds the `forbid_manual_screenshot_theme` lint rule (CA-912). The rule fires exclusively in `*_screenshot_test.dart` files and flags two manual dual-theme patterns that CA-847's `screenshotThemeGroups` was built to replace:

- A `ThemeData?` nullable parameter on any function/method (collides with `no_optional_operators_in_tests` and forces `if/else` workarounds)
- A hard-coded `_dark.png` suffix passed directly to `matchesGoldenFile` (easy to forget or mistype across 44+ files)

Existing CA-805 files that intentionally use the old pattern can suppress with `// ignore_for_file: forbid_manual_screenshot_theme`.

### 2. REVIEW SUMMARY TABLE

No issues found.

## Test plan

- [ ] `flutter test` passes with all 430 tests green
- [ ] `forbid_manual_screenshot_theme_test.dart` covers: `ThemeData?` violation, `_dark.png` violation, both together, non-dark suffix (no violation), non-string arg (no violation), non-nullable ThemeData (no violation), non-screenshot file (skipped), production file (skipped), generated file (skipped), Windows-path handling, `analyze()` empty guard, `analyzeWithResolver` via resolver path
- [ ] Standalone checker count updated: 20 → 21
- [ ] `forbid_manual_screenshot_theme` listed in `_testOnlyRuleNames` so standalone checker routes screenshot test files correctly