### PR TITLE
chore: bump version to 0.6.0 and update changelog (#CA-912)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.6.0] - Enforce screenshotThemeGroups adoption
+
+### ✨ New Rules
+
+- **forbid_manual_screenshot_theme**: Flags manual dual-theme patterns in `*_screenshot_test.dart` files — `ThemeData?` parameters and hard-coded `_dark.png` suffixes in `matchesGoldenFile` calls. Use `screenshotThemeGroups` instead.
+
+---
+
 ## 0.5.0 - Forbid Raw Icon and Image Usage (minor)
 
 ### New Rule

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ripplearc_linter
 description: A custom lint library following best engineering practice 
-version: 0.5.0
+version: 0.6.0
 repository: https://github.com/ripplearc/ripplearc-flutter-lint
 
 environment:


### PR DESCRIPTION
### 1. PR SUMMARY

Version bump following the `forbid_manual_screenshot_theme` rule added in #70. New rule → minor bump: 0.5.0 → 0.6.0.

### 2. REVIEW SUMMARY TABLE

No issues found.

## Test plan

- [ ] `flutter test` passes
- [ ] `pubspec.yaml` version matches `CHANGELOG.md` entry
- [ ] Changelog entry is under `[0.6.0]` and describes the new rule accurately